### PR TITLE
Color Picker Position

### DIFF
--- a/src/client/ui/inputs/ColorInput.scss
+++ b/src/client/ui/inputs/ColorInput.scss
@@ -2,6 +2,7 @@
 
 :local(.colorInput){
   display: flex;
+  position: relative;
   :local(.block) {
     display: flex;
     align-items: center;
@@ -23,7 +24,7 @@
     :local(.cover) {
       position: fixed;
       top: 0px;
-      right: 0px;
+      right: 20px;
       bottom: 0px;
       left: 0px;
     }


### PR DESCRIPTION
- made the color picker respect to the container.
- made the click cover not to overlap with the scrollbar of the property panel.