### PR TITLE
Fix scene modification state

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "dev": "cross-env NODE_ENV=development node ./bin/spoke --https --no-open ./example",
-    "dev:http": "cross-env NODE_ENV=development node ./bin/spoke ./example",
+    "dev:http": "cross-env NODE_ENV=development node ./bin/spoke --no-open ./example",
     "dev:nopath": "cross-env NODE_ENV=development node ./bin/spoke",
     "build": "concurrently \"npm run build:server\" \"npm run build:client\"",
     "build:server": "babel src/server/ -d lib/server/",

--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -517,7 +517,7 @@ export default class Editor {
       component = await this.components.get(componentName).inflate(object, props);
 
       if (componentName === SceneReferenceComponent.componentName && props && props.src) {
-        const scene = this._loadSceneReference(props.src, object)
+        await this._loadSceneReference(props.src, object)
           .then(() => {
             if (component.propValidation.src !== true) {
               component.propValidation.src = true;
@@ -531,7 +531,6 @@ export default class Editor {
               this.signals.objectChanged.dispatch(object);
             }
           });
-        await scene;
       }
     } else {
       component = {

--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -221,6 +221,7 @@ export default class Editor {
     this.sceneInfo = {
       uri: uri,
       scene: scene,
+      modified: false,
       helperScene: this.helperScene,
       helpers: this.helpers,
       objects: this.objects
@@ -245,6 +246,8 @@ export default class Editor {
     this._setSceneDefaults(scene);
 
     this._setScene(scene);
+
+    this.signals.sceneModified.dispatch();
 
     return scene;
   }
@@ -305,6 +308,8 @@ export default class Editor {
     this._setScene(scene);
 
     this._addDependency(uri, scene);
+
+    this.signals.sceneModified.dispatch();
 
     return scene;
   }

--- a/src/client/editor/SceneLoader.js
+++ b/src/client/editor/SceneLoader.js
@@ -589,11 +589,12 @@ export async function loadScene(uri, addComponent, isRoot = true, ancestors) {
     ancestors = [];
   }
 
-  console.log("BPDEBUG loadScene", url, isRoot);
   if (!isRoot) {
-    const root = sceneDef.entities[sceneDef.root];
-    if (root && root.components) {
-      root.components = root.components.filter(component => !defaultLightComponentNames.includes(component.name));
+    const sceneRoot = sceneDef.entities[sceneDef.root];
+    if (sceneRoot && sceneRoot.components) {
+      sceneRoot.components = sceneRoot.components.filter(
+        component => !defaultLightComponentNames.includes(component.name)
+      );
     }
   }
 

--- a/src/client/editor/commands/AddComponentCommand.js
+++ b/src/client/editor/commands/AddComponentCommand.js
@@ -18,8 +18,9 @@ export default class AddComponentCommand extends Command {
   }
 
   execute() {
-    this.editor.addComponent(this.object, this.componentName);
-    this.editor.signals.objectChanged.dispatch(this.object);
+    this.editor.addComponent(this.object, this.componentName).then(() => {
+      this.editor.signals.objectChanged.dispatch(this.object);
+    });
   }
 
   undo() {

--- a/src/client/editor/commands/RemoveComponentCommand.js
+++ b/src/client/editor/commands/RemoveComponentCommand.js
@@ -23,7 +23,8 @@ export default class RemoveComponentCommand extends Command {
   }
 
   undo() {
-    this.editor.addComponent(this.object, this.componentName);
-    this.editor.signals.objectChanged.dispatch(this.object);
+    this.editor.addComponent(this.object, this.componentName).then(() => {
+      this.editor.signals.objectChanged.dispatch(this.object);
+    });
   }
 }

--- a/src/client/editor/components/AmbientLightComponent.js
+++ b/src/client/editor/components/AmbientLightComponent.js
@@ -10,8 +10,8 @@ export default class AmbientLightComponent extends BaseComponent {
     { name: "intensity", type: types.number, default: 1, min: 0 }
   ];
 
-  updateProperty(propertyName, value) {
-    super.updateProperty(propertyName, value);
+  async updateProperty(propertyName, value) {
+    await super.updateProperty(propertyName, value);
     switch (propertyName) {
       case "color":
         this._object.color.set(value);
@@ -21,9 +21,9 @@ export default class AmbientLightComponent extends BaseComponent {
     }
   }
 
-  static inflate(node, props) {
+  static async inflate(node, props) {
     const light = new THREE.AmbientLight();
-    const component = this._getOrCreateComponent(node, props, light);
+    const component = await this._getOrCreateComponent(node, props, light);
     node.add(light);
     return component;
   }

--- a/src/client/editor/components/BaseComponent.js
+++ b/src/client/editor/components/BaseComponent.js
@@ -70,6 +70,7 @@ export default class BaseComponent {
     return component;
   }
 
+  // inflate is intentionally async here since subclasses may want to await.
   static async inflate(node, props) {
     return this._getOrCreateComponent(node, props);
   }

--- a/src/client/editor/components/BaseComponent.js
+++ b/src/client/editor/components/BaseComponent.js
@@ -26,7 +26,8 @@ export default class BaseComponent {
     return this.props[propertyName];
   }
 
-  updateProperty(propertyName, value) {
+  // updateProperty is intentionally async here since subclasses may want to await.
+  async updateProperty(propertyName, value) {
     this.props[propertyName] = value;
   }
 
@@ -40,7 +41,7 @@ export default class BaseComponent {
     return {};
   }
 
-  static _getOrCreateComponent(node, props, object) {
+  static async _getOrCreateComponent(node, props, object) {
     props = { ...getDefaultsFromSchema(this.schema), ...this._propsFromObject(node), ...props };
     if (!node.userData._components) {
       node.userData._components = [];
@@ -58,16 +59,18 @@ export default class BaseComponent {
       object.userData._dontExport = true;
     }
 
+    const propertyUpdatePromises = [];
     for (const key in props) {
       if (props.hasOwnProperty(key)) {
-        component.updateProperty(key, props[key]);
+        propertyUpdatePromises.push(component.updateProperty(key, props[key]));
       }
     }
+    await Promise.all(propertyUpdatePromises);
 
     return component;
   }
 
-  static inflate(node, props) {
+  static async inflate(node, props) {
     return this._getOrCreateComponent(node, props);
   }
 

--- a/src/client/editor/components/DirectionalLightComponent.js
+++ b/src/client/editor/components/DirectionalLightComponent.js
@@ -37,7 +37,7 @@ export default class DirectionalLightComponent extends BaseComponent {
 
   static async inflate(node, _props) {
     const light = new THREE.DirectionalLight();
-    const component = this._getOrCreateComponent(node, _props, light);
+    const component = await this._getOrCreateComponent(node, _props, light);
     node.add(light);
     return component;
   }

--- a/src/client/editor/components/DirectionalLightComponent.js
+++ b/src/client/editor/components/DirectionalLightComponent.js
@@ -17,8 +17,8 @@ export default class DirectionalLightComponent extends BaseComponent {
 
   static _tempEuler = new THREE.Euler(0, 0, 0, "YXZ");
 
-  updateProperty(propertyName, value) {
-    super.updateProperty(propertyName, value);
+  async updateProperty(propertyName, value) {
+    await super.updateProperty(propertyName, value);
     const { _tempEuler } = DirectionalLightComponent;
     switch (propertyName) {
       case "color":
@@ -35,7 +35,7 @@ export default class DirectionalLightComponent extends BaseComponent {
     }
   }
 
-  static inflate(node, _props) {
+  static async inflate(node, _props) {
     const light = new THREE.DirectionalLight();
     const component = this._getOrCreateComponent(node, _props, light);
     node.add(light);

--- a/src/client/editor/components/PointLightComponent.js
+++ b/src/client/editor/components/PointLightComponent.js
@@ -11,8 +11,8 @@ export default class PointLightComponent extends BaseComponent {
     { name: "castShadow", type: types.boolean, default: true }
   ];
 
-  updateProperty(propertyName, value) {
-    super.updateProperty(propertyName, value);
+  async updateProperty(propertyName, value) {
+    await super.updateProperty(propertyName, value);
     switch (propertyName) {
       case "color":
         this._object.color.set(value);
@@ -22,9 +22,9 @@ export default class PointLightComponent extends BaseComponent {
     }
   }
 
-  static inflate(node, _props) {
+  static async inflate(node, _props) {
     const light = new THREE.PointLight();
-    const component = this._getOrCreateComponent(node, _props, light);
+    const component = await this._getOrCreateComponent(node, _props, light);
     node.add(light);
     return component;
   }

--- a/src/client/editor/components/ShadowComponent.js
+++ b/src/client/editor/components/ShadowComponent.js
@@ -13,8 +13,8 @@ export default class ShadowComponent extends BaseComponent {
     { name: "receiveShadow", type: types.boolean, default: true }
   ];
 
-  updateProperty(propertyName, value) {
-    super.updateProperty(propertyName, value);
+  async updateProperty(propertyName, value) {
+    await super.updateProperty(propertyName, value);
     this._object[propertyName] = value;
 
     if (this._object.material) {

--- a/src/client/editor/components/SkyboxComponent.js
+++ b/src/client/editor/components/SkyboxComponent.js
@@ -29,7 +29,7 @@ export default class SkyboxComponent extends BaseComponent {
     this._object.material.uniforms.sunPosition.value.set(x, y, z).normalize();
   }
 
-  updateProperty(propertyName, value) {
+  async updateProperty(propertyName, value) {
     super.updateProperty(propertyName, value);
     const uniforms = this._object.material.uniforms;
     switch (propertyName) {
@@ -44,9 +44,9 @@ export default class SkyboxComponent extends BaseComponent {
     }
   }
 
-  static inflate(node, _props) {
+  static async inflate(node, _props) {
     const sky = new THREE.Sky();
-    const component = this._getOrCreateComponent(node, _props, sky);
+    const component = await this._getOrCreateComponent(node, _props, sky);
     node.add(sky);
     return component;
   }

--- a/src/client/editor/components/StandardMaterialComponent.js
+++ b/src/client/editor/components/StandardMaterialComponent.js
@@ -74,8 +74,8 @@ export default class StandardMaterialComponent extends SaveableComponent {
     }
   }
 
-  updateProperty(propertyName, value) {
-    super.updateProperty(propertyName, value);
+  async updateProperty(propertyName, value) {
+    await super.updateProperty(propertyName, value);
     if (!this._object) return;
     switch (propertyName) {
       case "color":
@@ -94,20 +94,20 @@ export default class StandardMaterialComponent extends SaveableComponent {
         this._object.side = value ? THREE.DoubleSide : THREE.FrontSide;
         break;
       case "baseColorTexture":
-        this._updateTexture(propertyName, "map", value, true);
+        await this._updateTexture(propertyName, "map", value, true);
         break;
       case "normalTexture":
-        this._updateTexture(propertyName, "normalMap", value);
+        await this._updateTexture(propertyName, "normalMap", value);
         break;
       case "metallicRoughnessTexture":
-        this._updateTexture(propertyName, "roughnessMap", value);
-        this._updateTexture(propertyName, "metalnessMap", value);
+        await this._updateTexture(propertyName, "roughnessMap", value);
+        await this._updateTexture(propertyName, "metalnessMap", value);
         break;
       case "emissiveTexture":
-        this._updateTexture(propertyName, "emissiveMap", value, true);
+        await this._updateTexture(propertyName, "emissiveMap", value, true);
         break;
       case "occlusionTexture":
-        this._updateTexture(propertyName, "aoMap", value);
+        await this._updateTexture(propertyName, "aoMap", value);
         break;
       default:
         this._object[propertyName] = value;
@@ -133,8 +133,8 @@ export default class StandardMaterialComponent extends SaveableComponent {
     };
   }
 
-  static inflate(node, _props) {
-    const component = this._getOrCreateComponent(node, _props, node.material || null);
+  static async inflate(node, _props) {
+    const component = await this._getOrCreateComponent(node, _props, node.material || null);
     component.props.baseColorTexture = component.props.baseColorTexture;
     component.props.normalTexture = component.props.normalTexture;
     component.props.metallicRoughnessTexture = component.props.metallicRoughnessTexture;

--- a/src/client/editor/components/StandardMaterialComponent.js
+++ b/src/client/editor/components/StandardMaterialComponent.js
@@ -135,11 +135,6 @@ export default class StandardMaterialComponent extends SaveableComponent {
 
   static async inflate(node, _props) {
     const component = await this._getOrCreateComponent(node, _props, node.material || null);
-    component.props.baseColorTexture = component.props.baseColorTexture;
-    component.props.normalTexture = component.props.normalTexture;
-    component.props.metallicRoughnessTexture = component.props.metallicRoughnessTexture;
-    component.props.emissiveTexture = component.props.emissiveTexture;
-    component.props.occlusionTexture = component.props.occlusionTexture;
     if (node.material) {
       node.material.envMap = envMap;
       node.material.needsUpdate = true;

--- a/src/client/editor/components/TransformComponent.js
+++ b/src/client/editor/components/TransformComponent.js
@@ -48,7 +48,7 @@ export default class TransformComponent extends BaseComponent {
     });
   }
 
-  updateProperty(propertyName, value) {
+  async updateProperty(propertyName, value) {
     this._object[propertyName].set(value.x, value.y, value.z);
   }
 }

--- a/src/client/ui/EditorContainer.js
+++ b/src/client/ui/EditorContainer.js
@@ -320,12 +320,13 @@ class EditorContainer extends Component {
       }
 
       editor.setSceneURI(sceneURI);
+
+      editor.signals.sceneGraphChanged.dispatch();
+
       editor.sceneInfo.modified = false;
       this.onSceneModified();
 
       this.hideDialog();
-
-      editor.signals.sceneGraphChanged.dispatch();
     } catch (e) {
       console.error(e);
       this.showDialog(ErrorDialog, {

--- a/src/client/ui/dialogs/ProgressDialog.js
+++ b/src/client/ui/dialogs/ProgressDialog.js
@@ -4,7 +4,7 @@ import styles from "./dialog.scss";
 import Button from "../Button";
 import Header from "../Header";
 
-export const PROGRESS_DIALOG_DELAY = 200;
+export const PROGRESS_DIALOG_DELAY = 500;
 
 export default function ProgressDialog({ title, message, cancelable, onCancel, cancelLabel, hideDialog }) {
   return (

--- a/src/client/ui/dialogs/ProgressDialog.js
+++ b/src/client/ui/dialogs/ProgressDialog.js
@@ -4,7 +4,7 @@ import styles from "./dialog.scss";
 import Button from "../Button";
 import Header from "../Header";
 
-export const PROGRESS_DIALOG_DELAY = 500;
+export const PROGRESS_DIALOG_DELAY = 200;
 
 export default function ProgressDialog({ title, message, cancelable, onCancel, cancelLabel, hideDialog }) {
   return (

--- a/src/client/ui/panels/PropertiesPanelContainer.js
+++ b/src/client/ui/panels/PropertiesPanelContainer.js
@@ -176,7 +176,7 @@ class PropertiesPanelContainer extends Component {
           component.srcIsValid = true;
           component.shouldSave = true;
           component.modified = false;
-          component.constructor.inflate(this.state.object, await this.props.project.readJSON(component.src));
+          await component.constructor.inflate(this.state.object, await this.props.project.readJSON(component.src));
           this.props.editor.signals.objectChanged.dispatch(this.state.object);
           this.props.hideDialog();
         } catch (e) {


### PR DESCRIPTION
Ignore scene modification signals while the scene is loading
In order to do the above, I had to make `addComponent` (and subsequently `updateProperty` and `inflate`) asynchronous. This actually solves a number of issues and is just the right thing to do, since these operations are inherently async and we want to await on them, e.g. when loading scene references or material textures.

Fixes #97 