### PR TITLE
Make colorpicker pop over

### DIFF
--- a/src/client/ui/inputs/ColorInput.js
+++ b/src/client/ui/inputs/ColorInput.js
@@ -9,12 +9,37 @@ export default class ColorInput extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      targetBlock: null,
+      pickerX: 0,
+      pickerY: 0,
       displayColorPicker: false
     };
   }
 
-  handleClick = () => {
-    this.setState({ displayColorPicker: !this.state.displayColorPicker });
+  componentDidMount = () => {
+    window.addEventListener("resize", this.updateDimensions);
+  };
+
+  componentWillUnmount = () => {
+    window.removeEventListener("resize", this.updateDimensions);
+  };
+
+  updateDimensions = () => {
+    const target = this.state.targetBlock.getBoundingClientRect();
+    this.setState({
+      pickerX: target.left,
+      pickerY: target.y + target.height
+    });
+  };
+
+  handleClick = e => {
+    const target = e.currentTarget.getBoundingClientRect();
+    this.setState({
+      targetBlock: e.currentTarget,
+      pickerX: target.left,
+      pickerY: target.y + target.height,
+      displayColorPicker: !this.state.displayColorPicker
+    });
   };
 
   handleClose = () => {
@@ -30,8 +55,12 @@ export default class ColorInput extends Component {
     if (!this.state.displayColorPicker) {
       return null;
     }
+    const pos = {
+      left: this.state.pickerX,
+      top: this.state.pickerY
+    };
     return (
-      <div className={styles.popover}>
+      <div style={pos} className={styles.popover}>
         <div className={styles.cover} onClick={this.handleClose} />
         <div className={styles.colorPicker}>
           <SketchPicker

--- a/src/client/ui/inputs/ColorInput.scss
+++ b/src/client/ui/inputs/ColorInput.scss
@@ -26,11 +26,9 @@
   }
 
   :local(.popover) {
-    position: absolute;
-    z-index: 2;
+    position: fixed;
+    z-index: 100;
     box-shadow: $shadow-30;
-    right: 0;
-    top: 28px;
     :local(.cover) {
       position: fixed;
       left: 0;

--- a/src/client/vendor/react-mosaic-component/mosaic-window.scss
+++ b/src/client/vendor/react-mosaic-component/mosaic-window.scss
@@ -12,7 +12,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License@mixin 
+ * limitations under the License@mixin
  */
 @import './mixins';
 
@@ -69,7 +69,6 @@
     flex: 1;
     height: 0;
     background: white;
-    z-index: 1;
     overflow: hidden;
   }
 
@@ -112,7 +111,7 @@
     height: 100%;
     width: 100%;
     position: absolute;
-    z-index: 0;
+    z-index: -1;
     border: 1px solid black;
     max-height: 400px;
 


### PR DESCRIPTION
- flatten the z-index of `mosaic-window-body`.
- made the color picker on the top.
- fixes #157 