### PR TITLE
Feature/misc ux improvements

### DIFF
--- a/src/client/editor/ConflictHandler.js
+++ b/src/client/editor/ConflictHandler.js
@@ -1,4 +1,4 @@
-const namePattern = new RegExp("(.*)_\\d+$");
+const namePattern = new RegExp("(.*) \\d+$");
 function nodesToTree(nodes) {
   if (!nodes) {
     return;
@@ -77,7 +77,7 @@ export default class ConflictHandler {
     if (this._duplicateNameCounters.has(name)) {
       const nameObj = this._duplicateNameCounters.get(name);
       nameObj.count++;
-      node.userData._resolvedName = name + "_" + nameObj.count;
+      node.userData._resolvedName = name + " " + nameObj.count;
       this._updatedNodes.set(this._hashTreePath(node.userData._path), node.userData._resolvedName);
     } else {
       this._duplicateNameCounters.set(name, { used: true, count: 0 });
@@ -267,10 +267,10 @@ export default class ConflictHandler {
       return name;
     } else {
       let n = this._duplicateNameCounters.get(cacheName).count + 1;
-      let newName = cacheName + "_" + n;
+      let newName = cacheName + " " + (n + 1);
       while (!this.isUniqueObjectName(newName)) {
         n += 1;
-        newName = cacheName + "_" + n;
+        newName = cacheName + " " + (n + 1);
       }
       this._duplicateNameCounters.get(cacheName).count = n;
       this._duplicateNameCounters.set(newName, { used: true });

--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -310,6 +310,7 @@ export default class Editor {
     );
     this.addUnicomponentNode("Skybox", "skybox", false);
     this.addUnicomponentNode("Ambient Light", "ambient-light", false, {}, { position: { x: 0, y: 10, z: 0 } });
+    this.addUnicomponentNode("Spawn Point", "spawn-point", false);
     this._ignoreSceneModification = false;
   }
 

--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -1204,13 +1204,13 @@ export default class Editor {
     let helper;
 
     if (object instanceof THREE.Camera) {
-      helper = new THREE.CameraHelper(object, 1);
+      helper = new THREE.CameraHelper(object);
     } else if (object instanceof THREE.PointLight) {
       helper = new THREE.PointLightHelper(object, 1);
     } else if (object instanceof THREE.DirectionalLight && object.name !== "_defaultDirectionalLight") {
       helper = new SpokeDirectionalLightHelper(object, 1);
     } else if (object instanceof THREE.SpotLight) {
-      helper = new THREE.SpotLightHelper(object, 1);
+      helper = new THREE.SpotLightHelper(object);
     } else if (object instanceof THREE.HemisphereLight) {
       helper = new SpokeHemisphereLightHelper(object, 1);
     } else if (object instanceof THREE.SkinnedMesh) {

--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -297,7 +297,6 @@ export default class Editor {
   }
 
   _createDefaultSceneObjects() {
-    this.addUnicomponentNode("Skybox", "skybox");
     this.addUnicomponentNode(
       "Sun",
       "directional-light",
@@ -307,6 +306,7 @@ export default class Editor {
         rotation: { x: Math.PI * 0.5, y: Math.PI * (0.5 / 3.0), z: -Math.PI * 0.5 }
       }
     );
+    this.addUnicomponentNode("Skybox", "skybox");
     this.addUnicomponentNode("Ambient Light", "ambient-light", {}, { position: { x: 0, y: 10, z: 0 } });
   }
 

--- a/src/client/editor/components/BoxColliderComponent.js
+++ b/src/client/editor/components/BoxColliderComponent.js
@@ -18,7 +18,6 @@ export default class BoxColliderComponent extends TransformComponent {
   static async inflate(node, _props) {
     const boxMesh = new THREE.Mesh(this._geometry, this._material);
     const box = new THREE.BoxHelper(boxMesh, 0x00ff00);
-    box.userData._selectionRoot = node;
     Object.defineProperty(box.userData, "_selectionRoot", { value: node, configurable: true, enumerable: false });
     box.userData._dontExport = true;
     box.userData._dontShowInHierarchy = true;

--- a/src/client/editor/components/SkyboxComponent.js
+++ b/src/client/editor/components/SkyboxComponent.js
@@ -14,7 +14,7 @@ export default class SkyboxComponent extends BaseComponent {
     { name: "mieCoefficient", type: types.number, default: 0.005 },
     { name: "mieDirectionalG", type: types.number, default: 0.8 },
     { name: "inclination", type: types.number, default: 0 },
-    { name: "azimuth", type: types.number, default: 0.25 },
+    { name: "azimuth", type: types.number, default: 0.15 },
     { name: "distance", type: types.number, default: 8000, min: 0, max: 1000 }
   ];
 

--- a/src/client/editor/components/utils.js
+++ b/src/client/editor/components/utils.js
@@ -16,6 +16,12 @@ const material = new THREE.MeshBasicMaterial({ color: 0xff0000, visible: false }
 export function addPicker(parent, selectionRoot) {
   const picker = new THREE.Mesh(geometry, material);
   picker.name = "picker";
-  picker.userData._selectionRoot = selectionRoot;
+
+  Object.defineProperty(picker.userData, "_selectionRoot", {
+    value: selectionRoot,
+    configurable: true,
+    enumerable: false
+  });
+
   parent.add(picker);
 }

--- a/src/client/ui/AddNodeActionButtons.js
+++ b/src/client/ui/AddNodeActionButtons.js
@@ -60,19 +60,6 @@ class AddNodeActionButtons extends Component {
     this.setState({ open: false });
   };
 
-  addOrSelectSkybox = () => {
-    const editor = this.props.editor;
-    const existingSkybox = editor.findFirstWithComponent("skybox");
-
-    if (existingSkybox) {
-      editor.select(existingSkybox);
-    } else {
-      editor.addUnicomponentNode("Skybox", "skybox");
-    }
-
-    this.setState({ open: false });
-  };
-
   addModel = () => {
     this.props.showDialog(AddModelDialog, {
       title: "Add Model",
@@ -135,11 +122,19 @@ class AddNodeActionButtons extends Component {
       [styles.fabClosed]: !this.state.open
     };
 
+    const hasSkybox = !!this.props.editor.findFirstWithComponent("skybox");
+
     return (
       <div className={styles.addNodeActionButtons}>
         {this.state.open && (
           <div className={styles.actionButtonContainer}>
-            <AddButton label="Skybox" iconClassName={SkyboxComponent.iconClassName} onClick={this.addOrSelectSkybox} />
+            {!hasSkybox && (
+              <AddButton
+                label="Skybox"
+                iconClassName={SkyboxComponent.iconClassName}
+                onClick={() => this.addNodeWithComponent("skybox")}
+              />
+            )}
             <AddButton
               label="Collider"
               iconClassName={BoxColliderComponent.iconClassName}

--- a/src/client/ui/EditorContainer.js
+++ b/src/client/ui/EditorContainer.js
@@ -193,6 +193,7 @@ class EditorContainer extends Component {
     this.props.editor.signals.windowResize.dispatch();
     this.props.editor.signals.sceneModified.add(this.onSceneModified);
     this.props.editor.signals.editorError.add(this.onEditorError);
+    this.updateDocumentTitle();
 
     window.onbeforeunload = e => {
       if (!this.props.editor.sceneModified()) {
@@ -391,6 +392,10 @@ class EditorContainer extends Component {
   };
 
   onSceneModified = () => {
+    this.updateDocumentTitle();
+  };
+
+  updateDocumentTitle = () => {
     const modified = this.props.editor.sceneModified() ? "*" : "";
     document.title = `Spoke - ${this.props.editor.scene.name}${modified}`;
   };

--- a/src/client/ui/EditorContainer.js
+++ b/src/client/ui/EditorContainer.js
@@ -397,7 +397,7 @@ class EditorContainer extends Component {
 
   updateDocumentTitle = () => {
     const modified = this.props.editor.sceneModified() ? "*" : "";
-    document.title = `Spoke - ${this.props.editor.scene.name}${modified}`;
+    document.title = `Spoke - ${modified}${this.props.editor.scene.name}`;
   };
 
   /**

--- a/src/client/ui/menus/ToolBar.js
+++ b/src/client/ui/menus/ToolBar.js
@@ -138,7 +138,7 @@ export default class ToolBar extends Component {
       );
     } else {
       return (
-        <SubMenu key={menu.name} title={menu.name}>
+        <SubMenu key={menu.name} title={menu.name} hoverDelay={0}>
           {menu.items.map(item => {
             return this.renderMenus(item);
           })}


### PR DESCRIPTION
This PR:

- Uses a space instead of underscore for numeric de-duplication of names, and also starts counting properly (so second light is #2 not #1)

- Removes the concept of "default lights" and instead always adds some default to the new scene (namely an ambient light, a directional (sun) light, a skybox, and a spawn point at the origin.)

- Disables the delay on the submenus

- Fixes a bug where the spotlight cone is always black

- Fixes a bug causing infinite recursion on export if you had a light in the scene

- Hides the add skybox button if you already have one (and now, you have one by default)

- Puts the "modified" asterisk in the title before the scene name, so when tabs shrink or for long scene names it will be visible