### PR TITLE
Fix up defaults for npm run dev/open

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Easily create custom 3D environments for [Mozilla Hubs](https://hubs.mozilla.com
 - [Download](https://github.com/MozillaReality/Spoke/archive/master.zip) and extract this repo
 - `cd Spoke-master`
 - `npm ci`
-- `npm run dev:http`
+- `npm run dev`
 
 Then open http://localhost:9090.
 
 ## Credits
 
-Parts of this project are derived from the [three.js editor](https://threejs.org/editor/) 
+Parts of this project are derived from the [three.js editor](https://threejs.org/editor/)
 with thanks to [Mr.doob](https://github.com/mrdoob) and three.js' many contributors.
 
 See the [LICENSE](LICENSE) for details.

--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
     "url": "https://github.com/MozillaReality/spoke.git"
   },
   "scripts": {
-    "dev": "cross-env NODE_ENV=development node ./bin/spoke --https --no-open ./example",
-    "dev:http": "cross-env NODE_ENV=development node ./bin/spoke --no-open ./example",
-    "open": "cross-env NODE_ENV=development node ./bin/spoke --https",
+    "dev": "cross-env NODE_ENV=development node ./bin/spoke --no-open example",
+    "open": "cross-env NODE_ENV=development node ./bin/spoke",
     "build": "concurrently \"npm run build:server\" \"npm run build:client\"",
     "build:server": "babel src/server/ -d lib/server/",
     "build:client": "webpack --mode production",


### PR DESCRIPTION
It seems like there's no reason we ever want to run the server over HTTPS nowadays, so let's not make it the default for things. Now it's easier to do `npm open foo` and have the configuration you want for opening project `foo`.