### PR TITLE
Export a preview camera into the GLTF

### DIFF
--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -886,6 +886,16 @@ export default class Editor {
     const scene = this.scene;
     const clonedScene = scene.clone();
 
+    // Add a preview camera to the exported GLB if there is a transform in the metadata.
+    const { previewCameraTransform } = this.getSceneMetadata();
+
+    if (previewCameraTransform) {
+      const previewCamera = this.DEFAULT_CAMERA.clone();
+      previewCamera.name = "Preview Camera";
+      previewCamera.applyMatrix(previewCameraTransform);
+      clonedScene.add(previewCamera);
+    }
+
     computeAndSetStaticModes(clonedScene);
 
     const meshesToCombine = [];

--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -891,7 +891,7 @@ export default class Editor {
 
     if (previewCameraTransform) {
       const previewCamera = this.DEFAULT_CAMERA.clone();
-      previewCamera.name = "Preview Camera";
+      previewCamera.name = "scene-preview-camera";
       previewCamera.applyMatrix(previewCameraTransform);
       clonedScene.add(previewCamera);
     }

--- a/src/client/editor/Viewport.js
+++ b/src/client/editor/Viewport.js
@@ -322,7 +322,15 @@ export default class Viewport {
     this._camera.layers.disable(1);
     this._renderer.render(this._editor.scene, this._camera);
     this._camera.layers.enable(1);
-    return new Promise(resolve => this._canvas.toBlob(resolve));
+
+    this._camera.updateMatrixWorld();
+    const cameraTransform = this._camera.matrixWorld.clone();
+
+    return new Promise(resolve => {
+      this._canvas.toBlob(blob => {
+        resolve({ blob, cameraTransform });
+      });
+    });
   };
 
   toggleSnap = () => {

--- a/src/client/ui/EditorContainer.js
+++ b/src/client/ui/EditorContainer.js
@@ -768,7 +768,10 @@ class EditorContainer extends Component {
   };
 
   _showPublishDialog = async () => {
-    const screenshotBlob = await this.props.editor.takeScreenshot();
+    const {
+      blob: screenshotBlob,
+      cameraTransform: screenshotCameraTransform
+    } = await this.props.editor.takeScreenshot();
     const attribution = this.props.editor.getSceneAttribution();
     const screenshotURL = URL.createObjectURL(screenshotBlob);
     const { name, description, allowRemixing, allowPromotion, sceneId } = this.props.editor.getSceneMetadata();
@@ -791,7 +794,13 @@ class EditorContainer extends Component {
           message: "Publishing scene..."
         });
 
-        this.props.editor.setSceneMetadata({ name, description, allowRemixing, allowPromotion });
+        this.props.editor.setSceneMetadata({
+          name,
+          description,
+          allowRemixing,
+          allowPromotion,
+          previewCameraTransform: screenshotCameraTransform
+        });
 
         let publishResult;
         try {


### PR DESCRIPTION
This PR exports a camera into the GLTF for the preview on the scene page. For now, the camera is set up as taking on the transform from the screenshot's camera.