### PR TITLE
Add hidden files

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -261,6 +261,7 @@ export default async function startServer(options) {
     mount(
       "/api/files/",
       serve(projectPath, {
+        hidden: true,
         setHeaders: res => {
           res.setHeader("Access-Control-Allow-Origin", "*");
         }


### PR DESCRIPTION
I ran into an issue where one of the Sketchfab scenes had texture files that began with a "." and so were considered hidden files, which are not available from the API before this PR. Does this seem safe to do?