### PR TITLE
Change npm run open to default npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "url": "https://github.com/MozillaReality/spoke.git"
   },
   "scripts": {
+    "start": "cross-env NODE_ENV=development node ./bin/spoke",
     "dev": "cross-env NODE_ENV=development node ./bin/spoke --no-open example",
-    "open": "cross-env NODE_ENV=development node ./bin/spoke",
     "build": "cross-env NODE_ENV=production webpack --mode production",
     "binaries": "npm run build && node package.js",
     "precommit": "lint-staged",


### PR DESCRIPTION
Now that we use a default project directory, it's probably best to have npm start just run against that directory.