### PR TITLE
Fix gltf-model error message and undefined name

### DIFF
--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -1436,7 +1436,9 @@ export default class Editor {
     } catch (e) {
       console.error("Failed to load GLTF", e);
 
-      this.signals.editorError.dispatch(new Error(`Failed to load GLTF ${e}`));
+      const errorMessage = e.message || "An unknown error occurred.";
+
+      this.signals.editorError.dispatch(new Error(`Failed to load GLTF: ${errorMessage}`));
 
       if (component.propValidation.src !== false) {
         component.propValidation.src = false;

--- a/src/client/ui/dialogs/FileDialog.js
+++ b/src/client/ui/dialogs/FileDialog.js
@@ -254,7 +254,7 @@ class FileDialog extends Component {
     e.preventDefault();
 
     if (this.state.selectedFile) {
-      this.props.onConfirm(this.state.selectedFile.uri);
+      this.props.onConfirm(this.state.selectedFile.uri, this.state.fileName);
       return;
     }
 
@@ -277,7 +277,7 @@ class FileDialog extends Component {
     const directoryURI = this.state.selectedDirectory || this.state.tree.uri;
 
     if (fileName.length > 0) {
-      this.props.onConfirm(directoryURI + "/" + fileName);
+      this.props.onConfirm(directoryURI + "/" + fileName, fileName);
     } else {
       this.props.onConfirm(directoryURI);
     }


### PR DESCRIPTION
- Prints out `An unknown error occurred.` instead of serializing the error object (`Failed to load GLTF: [object]`) when an error without a message is thrown in the gltf-model component.
- Passes the file name as a second argument when confirming the file dialog. This is passed to the gltf-model component and was previously undefined.