### PR TITLE
Tweak nav mesh parameters

### DIFF
--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -864,8 +864,13 @@ export default class Editor {
       const box = new THREE.Box3().setFromBufferAttribute(finalGeo.attributes.position);
       const size = new THREE.Vector3();
       box.getSize(size);
-      if (Math.max(size.x, size.y, size.z) > 2000) {
-        throw new Error(`Scene is too large (${size.x} x ${size.y} x ${size.z}) to generate a nav mesh.`);
+
+      if (size.x * size.y * size.z > 1000000) {
+        throw new Error(
+          `Scene is too large (${size.x} x ${size.y} x ${
+            size.z
+          }) to generate a nav mesh. Maximum volume is 1,000,000 cubic meters.`
+        );
       }
 
       const { navPosition, navIndex } = generateNavMesh(position, index);

--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -867,10 +867,8 @@ export default class Editor {
       if (Math.max(size.x, size.y, size.z) > 2000) {
         throw new Error(`Scene is too large (${size.x} x ${size.y} x ${size.z}) to generate a nav mesh.`);
       }
-      const area = size.x * size.z;
-      // Tuned to produce cell sizes from ~0.5 to ~1.5 for areas from ~200 to ~350,000.
-      const cellSize = Math.pow(area, 1 / 3) / 50;
-      const { navPosition, navIndex } = generateNavMesh(position, index, cellSize);
+
+      const { navPosition, navIndex } = generateNavMesh(position, index);
 
       const navGeo = new THREE.BufferGeometry();
       navGeo.setIndex(navIndex);

--- a/src/client/utils/navmesh.js
+++ b/src/client/utils/navmesh.js
@@ -6,13 +6,13 @@ Recast().then(r => {
   recast = r;
 });
 
-export function generateNavMesh(positions, indices, cellSize) {
+export function generateNavMesh(positions, indices) {
   if (!recast) {
     throw new Error("Recast module unavailable or not yet loaded.");
   }
   recast.loadArray(positions, indices);
   const objMesh = recast.build(
-    cellSize,
+    0.25, // cellSize
     0.1, // cellHeight
     1.0, // agentHeight
     0.0001, // agentRadius


### PR DESCRIPTION
Currently the nav mesh generation uses a cell size that is based on the area of the bounding box of the environment. This produces a cell size that can be too large and result in doorways and halls that are blocked. I propose that we set the cell size to a constant 0.25 meters. In my testing this generates a correct navmesh for correctly sized doorways and halls.

If reducing the cell size results in navmesh generation times that are too long in larger environments, I would suggest that we reduce the maximum size of the environment. I believe it is more crucial for us to have smaller environments where the expected areas are traversable than large wide open areas.

It also seems to make sense to expose some of these navmesh settings at some point. Cell size, cell height, agent max slope, region min size, etc. are all things that could be adjusted based on the features of your environment. Once we have the time to introduce the UI I'd like to expose those settings.