### PR TITLE
Migrate glTF namespace HUBS_components -> MOZ_hubs_components

### DIFF
--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -1047,8 +1047,8 @@ export default class Editor {
       if (userData.gltfExtensions === undefined) {
         userData.gltfExtensions = {};
       }
-      if (userData.gltfExtensions.HUBS_components === undefined) {
-        userData.gltfExtensions.HUBS_components = {};
+      if (userData.gltfExtensions.MOZ_hubs_components === undefined) {
+        userData.gltfExtensions.MOZ_hubs_components = {};
       }
     }
 
@@ -1056,13 +1056,13 @@ export default class Editor {
     clonedScene.traverse(object => {
       const userData = object.userData;
 
-      // Move component data to userData.extensions.HUBS_components
+      // Move component data to userData.extensions.MOZ_hubs_components
       if (userData._components) {
         for (const component of userData._components) {
           if (componentsToExport.includes(component.name)) {
             ensureHubsComponents(userData);
 
-            userData.gltfExtensions.HUBS_components[component.name] = component.props;
+            userData.gltfExtensions.MOZ_hubs_components[component.name] = component.props;
           }
         }
       }
@@ -1071,7 +1071,7 @@ export default class Editor {
       if (object.isMesh && (object.castShadow || object.receiveShadow)) {
         ensureHubsComponents(object.userData);
 
-        object.userData.gltfExtensions.HUBS_components.shadow = {
+        object.userData.gltfExtensions.MOZ_hubs_components.shadow = {
           castShadow: object.castShadow,
           receiveShadow: object.receiveShadow
         };


### PR DESCRIPTION
We currently do not have the `HUBS` glTF vendor prefix registered and should probably not be publishing assets with it. Instead of registering a new vendor prefix for Hubs, which at this point seems more like a product than a vendor, I propose we use the `MOZ_hubs_` prefix for all Hubs specific extensions.

If you'd like to read more on this topic see this glTF issue: https://github.com/KhronosGroup/glTF/issues/1387