### PR TITLE
Added includeInFloorPlan prop and always remove FloorPlan on generation.

### DIFF
--- a/src/client/editor/components/GLTFModelComponent.js
+++ b/src/client/editor/components/GLTFModelComponent.js
@@ -12,6 +12,7 @@ export default class GLTFModelComponent extends BaseComponent {
 
   static schema = [
     { name: "src", type: types.file, filters: [".gltf", ".glb"], default: null },
+    { name: "includeInFloorPlan", type: types.boolean, default: true },
     { name: "attribution", type: types.string, hidden: true },
     { name: "origin", type: types.string, hidden: true }
   ];

--- a/src/client/ui/EditorContainer.js
+++ b/src/client/ui/EditorContainer.js
@@ -196,7 +196,7 @@ class EditorContainer extends Component {
             action: e => this.onExportScene(e)
           },
           {
-            name: "Generate Nav Mesh",
+            name: "Generate Floor Plan",
             action: e => this.onGenerateNavMesh(e)
           },
           {


### PR DESCRIPTION
- Added `includeInFloorPlan` to the `gltf-model` component. This should help users exclude far away meshes that will increase the resolution of their FloorPlan, or just filter out meshes that they don't want users to navigate to.
- Always remove the first nav-mesh object and associated generated file before generating a nav mesh.
- Changed text in the file menu from `Generate nav mesh` to `Generate Floor Plan`