### PR TITLE
Merge meshes in animated glTF models

### DIFF
--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -1362,12 +1362,17 @@ export default class Editor {
           object.remove(component._object);
         }
 
-        const animations = scene.animations;
+        setStaticMode(scene, StaticModes.Static);
 
+        const animations = scene.animations;
         if (animations.length > 0) {
-          setStaticMode(scene, StaticModes.Dynamic);
-        } else {
-          setStaticMode(scene, StaticModes.Static);
+          for (const animation of animations) {
+            for (const track of animation.tracks) {
+              const { nodeName } = THREE.PropertyBinding.parseTrackName(track.name);
+              const animatedNode = scene.getObjectByName(nodeName);
+              setStaticMode(animatedNode, StaticModes.Dynamic);
+            }
+          }
         }
 
         object.add(scene);


### PR DESCRIPTION
Merges meshes in animated models by marking animated nodes as dynamic. Results in significantly less draw calls in environments using models like this: https://sketchfab.com/models/7984bd6024db4b89928ddeb625eebac0

<img width="843" alt="screen shot 2018-10-25 at 2 10 00 pm" src="https://user-images.githubusercontent.com/1753624/47530547-bed62c80-d85f-11e8-8463-bd1d68f0e989.png">
