### PR TITLE
Fix exporting ambient occlusion on a second uv set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spoke-cli",
-  "version": "0.5.8",
+  "version": "0.5.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13933,8 +13933,8 @@
       }
     },
     "three": {
-      "version": "github:mozillareality/three.js#748e5992948bc182a4b3890897c71d6539524dea",
-      "from": "github:mozillareality/three.js#hubs/dev-v2"
+      "version": "github:mozillareality/three.js#220c52eb20b5d8afce8aecc295283d7a7a1e0c62",
+      "from": "github:mozillareality/three.js#220c52eb20b5d8afce8aecc295283d7a7a1e0c62"
     },
     "throttle-debounce": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "semver": "^5.5.1",
     "sha.js": "^2.4.11",
     "signals": "^1.0.0",
-    "three": "github:mozillareality/three.js#hubs/dev-v2",
+    "three": "github:mozillareality/three.js#220c52eb20b5d8afce8aecc295283d7a7a1e0c62",
     "throttle-debounce": "^2.0.1",
     "uuid": "^3.3.2",
     "ws": "^5.2.0",


### PR DESCRIPTION
Fixes exporting ambient occlusion on a second uv set. If you want to bake AO into a texture atlas mapped to the second uv set you can now do so.