### PR TITLE
Fix Cloning TransformControls

### DIFF
--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -1,6 +1,6 @@
 import signals from "signals";
 import uuid from "uuid/v4";
-import * as THREE from "three";
+import THREE from "../vendor/three";
 import History from "./History";
 import Viewport from "./Viewport";
 

--- a/src/client/editor/MeshCombinationGroup.js
+++ b/src/client/editor/MeshCombinationGroup.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../vendor/three";
 import { isStatic } from "./StaticMode";
 import asyncTraverse from "./utils/asyncTraverse";
 import keysEqual from "./utils/keysEqual";

--- a/src/client/editor/Viewport.js
+++ b/src/client/editor/Viewport.js
@@ -1,8 +1,9 @@
-import * as THREE from "three";
+import THREE from "../vendor/three";
 import SetPositionCommand from "./commands/SetPositionCommand";
 import SetRotationCommand from "./commands/SetRotationCommand";
 import SetScaleCommand from "./commands/SetScaleCommand";
 import GridHelper from "./helpers/GridHelper";
+import SpokeTransformControls from "./controls/SpokeTransformControls";
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -79,7 +80,7 @@ export default class Viewport {
 
     requestAnimationFrame(render);
 
-    this._transformControls = new THREE.TransformControls(camera, canvas);
+    this._transformControls = new SpokeTransformControls(camera, canvas);
     this._transformControls.addEventListener("change", () => {
       const object = this._transformControls.object;
 

--- a/src/client/editor/caches/GLTFCache.js
+++ b/src/client/editor/caches/GLTFCache.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import Cache from "./Cache";
 import cloneObject3D from "../utils/cloneObject3D";
 

--- a/src/client/editor/caches/TextureCache.js
+++ b/src/client/editor/caches/TextureCache.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import Cache from "./Cache";
 
 const textureLoader = new THREE.TextureLoader();

--- a/src/client/editor/commands/MoveObjectCommand.js
+++ b/src/client/editor/commands/MoveObjectCommand.js
@@ -1,5 +1,5 @@
 import Command from "./Command";
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 /**
  * @author dforrer / https://github.com/dforrer

--- a/src/client/editor/controls/SpokeTransformControls.js
+++ b/src/client/editor/controls/SpokeTransformControls.js
@@ -1,0 +1,8 @@
+import THREE from "../../vendor/three";
+
+export default class SpokeTransformControls extends THREE.TransformControls {
+  clone() {
+    // You can only have one instance of TransformControls so return a dummy object when cloning.
+    return new THREE.Object3D().copy(this);
+  }
+}

--- a/src/client/editor/helpers/GridHelper.js
+++ b/src/client/editor/helpers/GridHelper.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class GridHelper extends THREE.GridHelper {
   constructor() {

--- a/src/client/editor/helpers/SpokeDirectionalLightHelper.js
+++ b/src/client/editor/helpers/SpokeDirectionalLightHelper.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class SpokeDirectionalLightHelper extends THREE.Object3D {
   constructor(light, size, color) {

--- a/src/client/editor/helpers/SpokePointLightHelper.js
+++ b/src/client/editor/helpers/SpokePointLightHelper.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class SpokePointLightHelper extends THREE.Mesh {
   constructor(light, sphereSize) {

--- a/src/client/editor/helpers/SpokeSpotLightHelper.js
+++ b/src/client/editor/helpers/SpokeSpotLightHelper.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class SpokeSpotLightHelper extends THREE.Object3D {
   constructor(light, color) {

--- a/src/client/editor/nodes/AmbientLightNode.js
+++ b/src/client/editor/nodes/AmbientLightNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import serializeColor from "../utils/serializeColor";
 

--- a/src/client/editor/nodes/BoxColliderNode.js
+++ b/src/client/editor/nodes/BoxColliderNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 
 export default class BoxColliderNode extends EditorNodeMixin(THREE.Object3D) {

--- a/src/client/editor/nodes/DirectionalLightNode.js
+++ b/src/client/editor/nodes/DirectionalLightNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import Picker from "../objects/Picker";
 import PhysicalDirectionalLight from "../objects/PhysicalDirectionalLight";

--- a/src/client/editor/nodes/FloorPlanNode.js
+++ b/src/client/editor/nodes/FloorPlanNode.js
@@ -1,5 +1,5 @@
 import EditorNodeMixin from "./EditorNodeMixin";
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import FloorPlan from "../objects/FloorPlan";
 import Recast from "../recast/recast.js";
 import ModelNode from "./ModelNode";

--- a/src/client/editor/nodes/GroundPlaneNode.js
+++ b/src/client/editor/nodes/GroundPlaneNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import GroundPlane from "../objects/GroundPlane";
 import serializeColor from "../utils/serializeColor";

--- a/src/client/editor/nodes/GroupNode.js
+++ b/src/client/editor/nodes/GroupNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 
 export default class GroupNode extends EditorNodeMixin(THREE.Group) {

--- a/src/client/editor/nodes/HemisphereLightNode.js
+++ b/src/client/editor/nodes/HemisphereLightNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import PhysicalHemisphereLight from "../objects/PhysicalHemisphereLight";
 import serializeColor from "../utils/serializeColor";

--- a/src/client/editor/nodes/ModelNode.js
+++ b/src/client/editor/nodes/ModelNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import Model from "../objects/Model";
 import EditorNodeMixin from "./EditorNodeMixin";
 import { setStaticMode, StaticModes } from "../StaticMode";

--- a/src/client/editor/nodes/PointLightNode.js
+++ b/src/client/editor/nodes/PointLightNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import Picker from "../objects/Picker";
 import PhysicalPointLight from "../objects/PhysicalPointLight";

--- a/src/client/editor/nodes/SceneNode.js
+++ b/src/client/editor/nodes/SceneNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import { setStaticMode, StaticModes, isStatic } from "../StaticMode";
 import sortEntities from "../utils/sortEntities";

--- a/src/client/editor/nodes/SkyboxNode.js
+++ b/src/client/editor/nodes/SkyboxNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import Sky from "../objects/Sky";
 

--- a/src/client/editor/nodes/SpawnPointNode.js
+++ b/src/client/editor/nodes/SpawnPointNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import spawnPointModelUrl from "../../assets/spawn-point.glb";
 

--- a/src/client/editor/nodes/SpotLightNode.js
+++ b/src/client/editor/nodes/SpotLightNode.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import Picker from "../objects/Picker";
 import PhysicalSpotLight from "../objects/PhysicalSpotLight";

--- a/src/client/editor/objects/FloorPlan.js
+++ b/src/client/editor/objects/FloorPlan.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class FloorPlan extends THREE.Object3D {
   constructor() {

--- a/src/client/editor/objects/GroundPlane.js
+++ b/src/client/editor/objects/GroundPlane.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class GroundPlane extends THREE.Object3D {
   static _geometry = new THREE.CircleBufferGeometry(4000, 32);

--- a/src/client/editor/objects/Model.js
+++ b/src/client/editor/objects/Model.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 import cloneObject3D from "../utils/cloneObject3D";
 
 export default class Model extends THREE.Object3D {

--- a/src/client/editor/objects/PhysicalDirectionalLight.js
+++ b/src/client/editor/objects/PhysicalDirectionalLight.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class PhysicalDirectionalLight extends THREE.DirectionalLight {
   constructor() {

--- a/src/client/editor/objects/PhysicalHemisphereLight.js
+++ b/src/client/editor/objects/PhysicalHemisphereLight.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class PhysicalHemisphereLight extends THREE.HemisphereLight {
   constructor() {

--- a/src/client/editor/objects/PhysicalPointLight.js
+++ b/src/client/editor/objects/PhysicalPointLight.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class PhysicalPointLight extends THREE.PointLight {
   constructor() {

--- a/src/client/editor/objects/PhysicalSpotLight.js
+++ b/src/client/editor/objects/PhysicalSpotLight.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class PhysicalSpotLight extends THREE.SpotLight {
   constructor() {

--- a/src/client/editor/objects/Picker.js
+++ b/src/client/editor/objects/Picker.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 const geometry = new THREE.SphereBufferGeometry(1, 4, 2);
 const material = new THREE.MeshBasicMaterial({ color: 0xff0000, visible: false });

--- a/src/client/editor/objects/Sky.js
+++ b/src/client/editor/objects/Sky.js
@@ -1,4 +1,4 @@
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 /**
  * @author zz85 / https://github.com/zz85
  *

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,14 +1,6 @@
 import ReactDOM from "react-dom";
 import React from "react";
 
-const THREE = require("three");
-window.THREE = THREE;
-require("three/examples/js/BufferGeometryUtils");
-require("three/examples/js/controls/EditorControls");
-require("three/examples/js/controls/TransformControls");
-require("three/examples/js/exporters/GLTFExporter");
-require("three/examples/js/loaders/GLTFLoader");
-
 import App from "./ui/App";
 import Editor from "./editor/Editor";
 import Project from "./api/Project";

--- a/src/client/ui/inputs/ColorInput.js
+++ b/src/client/ui/inputs/ColorInput.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { SketchPicker } from "react-color";
 import { EditableInput } from "react-color/lib/components/common";
 import styles from "./ColorInput.scss";
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 export default class ColorInput extends Component {
   static propTypes = {

--- a/src/client/ui/inputs/EulerInput.js
+++ b/src/client/ui/inputs/EulerInput.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styles from "./Vector3Input.scss";
 import NumericInput from "./NumericInput";
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 const { RAD2DEG, DEG2RAD } = THREE.Math;
 

--- a/src/client/ui/inputs/Vector3Input.js
+++ b/src/client/ui/inputs/Vector3Input.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styles from "./Vector3Input.scss";
 import NumericInput from "./NumericInput";
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 let uniqueId = 0;
 

--- a/src/client/ui/properties/SkyboxNodeEditor.js
+++ b/src/client/ui/properties/SkyboxNodeEditor.js
@@ -4,7 +4,7 @@ import NodeEditor from "./NodeEditor";
 import InputGroup from "../inputs/InputGroup";
 import NumericInput from "../inputs/NumericInput";
 import CompoundNumericInput from "../inputs/CompoundNumericInput";
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 const { degToRad, radToDeg } = THREE.Math;
 

--- a/src/client/ui/properties/SpotLightNodeEditor.js
+++ b/src/client/ui/properties/SpotLightNodeEditor.js
@@ -5,7 +5,7 @@ import InputGroup from "../inputs/InputGroup";
 import ColorInput from "../inputs/ColorInput";
 import NumericInput from "../inputs/NumericInput";
 import BooleanInput from "../inputs/BooleanInput";
-import * as THREE from "three";
+import THREE from "../../vendor/three";
 
 const { degToRad, radToDeg } = THREE.Math;
 

--- a/src/client/vendor/three.js
+++ b/src/client/vendor/three.js
@@ -1,0 +1,11 @@
+const THREE = require("three");
+
+window.THREE = THREE;
+
+require("three/examples/js/BufferGeometryUtils");
+require("three/examples/js/controls/EditorControls");
+require("three/examples/js/controls/TransformControls");
+require("three/examples/js/exporters/GLTFExporter");
+require("three/examples/js/loaders/GLTFLoader");
+
+export default THREE;


### PR DESCRIPTION
- Moves three.js back to a vendor file so that it can be required correctly.
- Introduces `SpokeTransformControls` which has the `.clone()` method overridden so that it returns an Object3D and avoids a bug with multiple instances of TransformControls.