### PR TITLE
Fix box collider component

### DIFF
--- a/src/client/editor/nodes/BoxColliderNode.js
+++ b/src/client/editor/nodes/BoxColliderNode.js
@@ -52,7 +52,11 @@ export default class BoxColliderNode extends EditorNodeMixin(THREE.Object3D) {
         "box-collider": {
           // TODO: Remove exporting these properties. They are already included in the transform props.
           position: this.position,
-          rotation: this.rotation,
+          rotation: {
+            x: this.rotation.x,
+            y: this.rotation.y,
+            z: this.rotation.z
+          },
           scale: this.scale
         }
       }

--- a/src/client/editor/nodes/BoxColliderNode.js
+++ b/src/client/editor/nodes/BoxColliderNode.js
@@ -49,7 +49,12 @@ export default class BoxColliderNode extends EditorNodeMixin(THREE.Object3D) {
   prepareForExport() {
     this.userData.gltfExtensions = {
       HUBS_components: {
-        "box-collider": {}
+        "box-collider": {
+          // TODO: Remove exporting these properties. They are already included in the transform props.
+          position: this.position,
+          rotation: this.rotation,
+          scale: this.scale
+        }
       }
     };
 

--- a/src/client/editor/nodes/GroundPlaneNode.js
+++ b/src/client/editor/nodes/GroundPlaneNode.js
@@ -38,9 +38,13 @@ export default class GroundPlaneNode extends EditorNodeMixin(GroundPlane) {
       HUBS_components: {
         "box-collider": {
           // TODO: Remove exporting these properties. They are already included in the transform props.
-          position: this.position,
-          rotation: this.rotation,
-          scale: this.scale
+          position: groundPlaneCollider.position,
+          rotation: {
+            x: groundPlaneCollider.rotation.x,
+            y: groundPlaneCollider.rotation.y,
+            z: groundPlaneCollider.rotation.z
+          },
+          scale: groundPlaneCollider.scale
         }
       }
     };

--- a/src/client/editor/nodes/GroundPlaneNode.js
+++ b/src/client/editor/nodes/GroundPlaneNode.js
@@ -36,7 +36,12 @@ export default class GroundPlaneNode extends EditorNodeMixin(GroundPlane) {
     groundPlaneCollider.scale.set(4000, 0.01, 4000);
     groundPlaneCollider.userData.gltfExtensions = {
       HUBS_components: {
-        "box-collider": {}
+        "box-collider": {
+          // TODO: Remove exporting these properties. They are already included in the transform props.
+          position: this.position,
+          rotation: this.rotation,
+          scale: this.scale
+        }
       }
     };
     this.add(groundPlaneCollider);


### PR DESCRIPTION
The `box-collider` component in Hubs expects transform properties which I forgot to export.