### PR TITLE
Set directional light position to a more visible default.

### DIFF
--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -161,7 +161,7 @@ export default class Editor {
     this._addObject(new SkyboxNode());
     this._addObject(new AmbientLightNode());
     const directionalLight = new DirectionalLightNode();
-    directionalLight.position.set(0, 10, 0);
+    directionalLight.position.set(-1, 3, 0);
     directionalLight.rotation.set(Math.PI * 0.5, Math.PI * (0.5 / 3.0), -Math.PI * 0.5);
     this._addObject(directionalLight);
     this._addObject(new SpawnPointNode());


### PR DESCRIPTION
This PR sets the position of the directional light in the default scene to (-1, 3, 0)

![screen shot 2018-11-06 at 4 21 25 pm](https://user-images.githubusercontent.com/1753624/48102486-0bb2ef00-e1e0-11e8-813b-28ed5d10bf9e.png)

Suggested by @j-conrad. Jim I tweaked the coordinates a little bit so that it's still visible but doesn't occlude the spawn point.