### PR TITLE
Make it easier to test with a local copy of Hubs.

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -3,3 +3,9 @@
 # The Reticulum backend to connect to. For uploading and publishing scenes to Hubs.
 # See here for the server code: https://github.com/mozilla/reticulum
 RETICULUM_SERVER="hubs.mozilla.com"
+
+# The Hubs backend to use for previewing published scenes.
+# The RETICULUM_SERVER must also be set to dev to avoid the CSP rules.
+# Uncomment both lines when testing with a local hubs instance.
+# HUBS_SERVER="localhost:8080"
+# RETICULUM_SERVER="dev.reticulum.io"

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -334,7 +334,12 @@ async function startServer(options) {
     };
   });
 
-  const reticulumServer = "hubs.mozilla.com";
+  const reticulumServer = process.env.RETICULUM_SERVER || "hubs.mozilla.com";
+
+  if (process.env.RETICULUM_SERVER) {
+    console.log(`Using RETICULUM_SERVER: ${reticulumServer}\n`);
+  }
+
   const mediaEndpoint = `https://${reticulumServer}/api/v1/media`;
   const agent = process.env.NODE_ENV === "development" ? https.Agent({ rejectUnauthorized: false }) : null;
 
@@ -544,7 +549,12 @@ async function startServer(options) {
     }
 
     const json = await resp.json();
-    const { url, scene_id } = json.scenes[0];
+    const scene_id = json.scenes[0].scene_id;
+    let url = json.scenes[0].url;
+
+    if (process.env.HUBS_SERVER) {
+      url = `https://${process.env.HUBS_SERVER}/scene.html?scene_id=${scene_id}`;
+    }
 
     ctx.body = { url, sceneId: scene_id };
   });


### PR DESCRIPTION
Introduces the `HUBS_SERVER` environment variable and uses the existing `RETICULUM_SERVER` environment variable in the server in order to make Spoke work seamlessly with a locally hosted Hubs server.