### PR TITLE
Fix cloning light targets

### DIFF
--- a/src/client/editor/objects/PhysicalDirectionalLight.js
+++ b/src/client/editor/objects/PhysicalDirectionalLight.js
@@ -18,7 +18,6 @@ export default class PhysicalDirectionalLight extends THREE.DirectionalLight {
     this.color.copy(source.color);
     this.intensity = source.intensity;
 
-    this.target = source.target.clone();
     this.shadow.copy(source.shadow);
 
     return this;

--- a/src/client/editor/objects/PhysicalSpotLight.js
+++ b/src/client/editor/objects/PhysicalSpotLight.js
@@ -51,8 +51,6 @@ export default class PhysicalSpotLight extends THREE.SpotLight {
     this.penumbra = source.penumbra;
     this.decay = source.decay;
 
-    this.target = source.target.clone();
-
     this.shadow.copy(source.shadow);
 
     return this;


### PR DESCRIPTION
Lights in spoke don't actually need the targets to be cloned. This was resulting in odd behavior when duplicating and rotating lights.