### PR TITLE
Prefilter environment map and rotate cube camera

### DIFF
--- a/src/client/editor/nodes/SkyboxNode.js
+++ b/src/client/editor/nodes/SkyboxNode.js
@@ -40,7 +40,7 @@ export default class SkyboxNode extends EditorNodeMixin(Sky) {
 
     this.skyScene = new THREE.Scene();
     this.cubeCamera = new THREE.CubeCamera(1, 100000, 512);
-    this.cubeCamera.scale(-1, 1, 1);
+    this.cubeCamera.scale.set(-1, 1, 1);
     this.skyScene.add(this.cubeCamera);
   }
 

--- a/src/client/editor/nodes/SkyboxNode.js
+++ b/src/client/editor/nodes/SkyboxNode.js
@@ -40,6 +40,7 @@ export default class SkyboxNode extends EditorNodeMixin(Sky) {
 
     this.skyScene = new THREE.Scene();
     this.cubeCamera = new THREE.CubeCamera(1, 100000, 512);
+    this.cubeCamera.rotation.set(0, Math.PI, 0);
     this.skyScene.add(this.cubeCamera);
   }
 
@@ -60,10 +61,17 @@ export default class SkyboxNode extends EditorNodeMixin(Sky) {
   }
 
   updateEnvironmentMap() {
+    const renderer = this.editor.viewport.renderer;
     this.skyScene.add(this.sky);
-    this.cubeCamera.update(this.editor.viewport.renderer, this.skyScene);
+    this.cubeCamera.update(renderer, this.skyScene);
     this.add(this.sky);
-    this.editor.scene.updateEnvironmentMap(this.cubeCamera.renderTarget.texture);
+    const pmremGenerator = new THREE.PMREMGenerator(this.cubeCamera.renderTarget.texture);
+    pmremGenerator.update(renderer);
+    const pmremCubeUVPacker = new THREE.PMREMCubeUVPacker(pmremGenerator.cubeLods);
+    pmremCubeUVPacker.update(renderer);
+    this.editor.scene.updateEnvironmentMap(pmremCubeUVPacker.CubeUVRenderTarget.texture);
+    pmremGenerator.dispose();
+    pmremCubeUVPacker.dispose();
   }
 
   serialize() {

--- a/src/client/editor/nodes/SkyboxNode.js
+++ b/src/client/editor/nodes/SkyboxNode.js
@@ -40,7 +40,7 @@ export default class SkyboxNode extends EditorNodeMixin(Sky) {
 
     this.skyScene = new THREE.Scene();
     this.cubeCamera = new THREE.CubeCamera(1, 100000, 512);
-    this.cubeCamera.rotation.set(0, Math.PI, 0);
+    this.cubeCamera.scale(-1, 1, 1);
     this.skyScene.add(this.cubeCamera);
   }
 

--- a/src/client/vendor/three.js
+++ b/src/client/vendor/three.js
@@ -7,5 +7,7 @@ require("three/examples/js/controls/EditorControls");
 require("three/examples/js/controls/TransformControls");
 require("three/examples/js/exporters/GLTFExporter");
 require("three/examples/js/loaders/GLTFLoader");
+require("three/examples/js/pmrem/PMREMGenerator");
+require("three/examples/js/pmrem/PMREMCubeUVPacker");
 
 export default THREE;


### PR DESCRIPTION
- Environment maps now respect material roughness.
- The cube camera now faces the correct direction for environment maps.