### PR TITLE
Fix scene lighting resulting from skybox environment map.

### DIFF
--- a/src/client/editor/Editor.js
+++ b/src/client/editor/Editor.js
@@ -20,7 +20,6 @@ import getNameWithoutIndex from "./utils/getNameWithoutIndex";
 
 import SceneNode from "./nodes/SceneNode";
 import GroundPlaneNode from "./nodes/GroundPlaneNode";
-import AmbientLightNode from "./nodes/AmbientLightNode";
 import DirectionalLightNode from "./nodes/DirectionalLightNode";
 import SpawnPointNode from "./nodes/SpawnPointNode";
 import SkyboxNode from "./nodes/SkyboxNode";
@@ -160,13 +159,18 @@ export default class Editor {
     this.setScene(scene);
 
     this._addObject(new SkyboxNode(this));
-    this._addObject(new AmbientLightNode(this));
     const directionalLight = new DirectionalLightNode(this);
     directionalLight.position.set(-1, 3, 0);
     directionalLight.rotation.set(Math.PI * 0.5, Math.PI * (0.5 / 3.0), -Math.PI * 0.5);
     this._addObject(directionalLight);
     this._addObject(new SpawnPointNode(this));
     this._addObject(new GroundPlaneNode(this));
+
+    this.scene.traverse(node => {
+      if (node.isNode) {
+        node.onRendererChanged();
+      }
+    });
 
     this.signals.sceneGraphChanged.dispatch();
     this.sceneModified = true;
@@ -192,7 +196,7 @@ export default class Editor {
 
     this.scene.traverse(node => {
       if (node.isNode) {
-        node.onAfterFirstRender();
+        node.onRendererChanged();
       }
     });
 

--- a/src/client/editor/nodes/EditorNodeMixin.js
+++ b/src/client/editor/nodes/EditorNodeMixin.js
@@ -68,7 +68,7 @@ export default function EditorNodeMixin(Object3DClass) {
 
     onDeselect() {}
 
-    onAfterFirstRender() {}
+    onRendererChanged() {}
 
     serialize() {
       return {

--- a/src/client/editor/nodes/SkyboxNode.js
+++ b/src/client/editor/nodes/SkyboxNode.js
@@ -44,7 +44,7 @@ export default class SkyboxNode extends EditorNodeMixin(Sky) {
     this.skyScene.add(this.cubeCamera);
   }
 
-  onAfterFirstRender() {
+  onRendererChanged() {
     this.updateEnvironmentMap();
   }
 


### PR DESCRIPTION
The environment map from the skybox has introduced a few new things when dealing with lighting. 

- The environment map needs to be updated when using the screenshot renderer.
  - This PR renames `onAfterFirstRender` to `onRendererChanged` to better reflect when that lifecycle method is called.
  - `onRendererChanged` is always called when a scene is being used with a new renderer. This happens when loading any scene (including the new scene) and when using another renderer when taking a screenshot.
  - I'm not satisfied with how we are accessing the renderer in the skybox node. Hopefully, we can come up with a better way in the near future.
- In environments with a skybox, the ambient light can make the scene seem ungrounded. I've removed it from the default scene to make it simpler for people to get the correct lighting in their scene. Users may still want to use ambient light in some scenes and it can still be added via the lights menu.


Fixes #421
Fixes #276 