### PR TITLE
Navmesh Revamp

### DIFF
--- a/src/client/editor/nodes/AmbientLightNode.js
+++ b/src/client/editor/nodes/AmbientLightNode.js
@@ -1,6 +1,5 @@
 import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
-import serializeColor from "../utils/serializeColor";
 
 export default class AmbientLightNode extends EditorNodeMixin(THREE.AmbientLight) {
   static legacyComponentName = "ambient-light";
@@ -21,32 +20,20 @@ export default class AmbientLightNode extends EditorNodeMixin(THREE.AmbientLight
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "ambient-light",
-      props: {
-        color: serializeColor(this.color),
+    return super.serialize({
+      "ambient-light": {
+        color: this.color,
         intensity: this.intensity
       }
     });
-
-    return json;
   }
 
   prepareForExport() {
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        "ambient-light": {
-          color: serializeColor(this.color),
-          intensity: this.intensity
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    super.prepareForExport();
+    this.addGLTFComponent("ambient-light", {
+      color: this.color,
+      intensity: this.intensity
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/nodes/BoxColliderNode.js
+++ b/src/client/editor/nodes/BoxColliderNode.js
@@ -26,7 +26,7 @@ export default class BoxColliderNode extends EditorNodeMixin(THREE.Object3D) {
     box.layers.set(1);
     this.helper = box;
     this.add(box);
-    this.walkable = true;
+    this.walkable = false;
   }
 
   copy(source, recursive) {

--- a/src/client/editor/nodes/BoxColliderNode.js
+++ b/src/client/editor/nodes/BoxColliderNode.js
@@ -10,6 +10,14 @@ export default class BoxColliderNode extends EditorNodeMixin(THREE.Object3D) {
 
   static _material = new THREE.Material();
 
+  static async deserialize(editor, json) {
+    const node = await super.deserialize(editor, json);
+
+    node.walkable = !!json.components.find(c => c.name === "walkable");
+
+    return node;
+  }
+
   constructor(editor) {
     super(editor);
 
@@ -18,6 +26,7 @@ export default class BoxColliderNode extends EditorNodeMixin(THREE.Object3D) {
     box.layers.set(1);
     this.helper = box;
     this.add(box);
+    this.walkable = true;
   }
 
   copy(source, recursive) {
@@ -32,36 +41,35 @@ export default class BoxColliderNode extends EditorNodeMixin(THREE.Object3D) {
       }
     }
 
+    this.walkable = source.walkable;
+
     return this;
   }
 
   serialize() {
-    const json = super.serialize();
+    const components = {
+      "box-collider": {}
+    };
 
-    json.components.push({
-      name: "box-collider",
-      props: {}
-    });
+    if (this.walkable) {
+      components.walkable = {};
+    }
 
-    return json;
+    return super.serialize(components);
   }
 
   prepareForExport() {
-    this.userData.gltfExtensions = {
-      HUBS_components: {
-        "box-collider": {
-          // TODO: Remove exporting these properties. They are already included in the transform props.
-          position: this.position,
-          rotation: {
-            x: this.rotation.x,
-            y: this.rotation.y,
-            z: this.rotation.z
-          },
-          scale: this.scale
-        }
-      }
-    };
-
+    super.prepareForExport();
     this.remove(this.helper);
+    this.addGLTFComponent("box-collider", {
+      // TODO: Remove exporting these properties. They are already included in the transform props.
+      position: this.position,
+      rotation: {
+        x: this.rotation.x,
+        y: this.rotation.y,
+        z: this.rotation.z
+      },
+      scale: this.scale
+    });
   }
 }

--- a/src/client/editor/nodes/DirectionalLightNode.js
+++ b/src/client/editor/nodes/DirectionalLightNode.js
@@ -1,8 +1,6 @@
-import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import PhysicalDirectionalLight from "../objects/PhysicalDirectionalLight";
 import SpokeDirectionalLightHelper from "../helpers/SpokeDirectionalLightHelper";
-import serializeColor from "../utils/serializeColor";
 
 export default class DirectionalLightNode extends EditorNodeMixin(PhysicalDirectionalLight) {
   static legacyComponentName = "directional-light";
@@ -69,12 +67,9 @@ export default class DirectionalLightNode extends EditorNodeMixin(PhysicalDirect
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "directional-light",
-      props: {
-        color: serializeColor(this.color),
+    return super.serialize({
+      "directional-light": {
+        color: this.color,
         intensity: this.intensity,
         castShadow: this.castShadow,
         shadowMapResolution: this.shadowMapResolution.toArray(),
@@ -82,29 +77,19 @@ export default class DirectionalLightNode extends EditorNodeMixin(PhysicalDirect
         shadowRadius: this.shadowRadius
       }
     });
-
-    return json;
   }
 
   prepareForExport() {
+    super.prepareForExport();
     this.remove(this.helper);
-
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        "directional-light": {
-          color: serializeColor(this.color),
-          intensity: this.intensity,
-          castShadow: this.castShadow,
-          shadowMapResolution: this.shadowMapResolution.toArray(),
-          shadowBias: this.shadowBias,
-          shadowRadius: this.shadowRadius
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    this.addGLTFComponent("directional-light", {
+      color: this.color,
+      intensity: this.intensity,
+      castShadow: this.castShadow,
+      shadowMapResolution: this.shadowMapResolution.toArray(),
+      shadowBias: this.shadowBias,
+      shadowRadius: this.shadowRadius
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/nodes/EditorNodeMixin.js
+++ b/src/client/editor/nodes/EditorNodeMixin.js
@@ -41,7 +41,7 @@ export default function EditorNodeMixin(Object3DClass) {
         const visibleComponent = json.components.find(c => c.name === "visible");
 
         if (visibleComponent) {
-          node.visible = visibleComponent.props.value;
+          node.visible = visibleComponent.props.visible;
         }
       }
 
@@ -106,7 +106,7 @@ export default function EditorNodeMixin(Object3DClass) {
           {
             name: "visible",
             props: {
-              value: this.visible
+              visible: this.visible
             }
           }
         ]

--- a/src/client/editor/nodes/EditorNodeMixin.js
+++ b/src/client/editor/nodes/EditorNodeMixin.js
@@ -6,6 +6,8 @@ import {
   isInherits,
   isStatic
 } from "../StaticMode";
+import THREE from "../../vendor/three";
+import serializeColor from "../utils/serializeColor";
 
 export default function EditorNodeMixin(Object3DClass) {
   return class extends Object3DClass {
@@ -34,6 +36,12 @@ export default function EditorNodeMixin(Object3DClass) {
           node.position.set(position.x, position.y, position.z);
           node.rotation.set(rotation.x, rotation.y, rotation.z);
           node.scale.set(scale.x, scale.y, scale.z);
+        }
+
+        const visibleComponent = json.components.find(c => c.name === "visible");
+
+        if (visibleComponent) {
+          node.visible = visibleComponent.props.value;
         }
       }
 
@@ -71,8 +79,8 @@ export default function EditorNodeMixin(Object3DClass) {
 
     onRendererChanged() {}
 
-    serialize() {
-      return {
+    serialize(components) {
+      const entityJson = {
         name: this.name,
         components: [
           {
@@ -94,12 +102,85 @@ export default function EditorNodeMixin(Object3DClass) {
                 z: this.scale.z
               }
             }
+          },
+          {
+            name: "visible",
+            props: {
+              value: this.visible
+            }
           }
         ]
       };
+
+      if (components) {
+        for (const componentName in components) {
+          const serializedProps = {};
+          const componentProps = components[componentName];
+
+          for (const propName in componentProps) {
+            const propValue = componentProps[propName];
+
+            if (propValue instanceof THREE.Color) {
+              serializedProps[propName] = serializeColor(propValue);
+            } else {
+              serializedProps[propName] = propValue;
+            }
+          }
+
+          entityJson.components.push({
+            name: componentName,
+            props: serializedProps
+          });
+        }
+      }
+
+      return entityJson;
     }
 
-    prepareForExport() {}
+    prepareForExport() {
+      if (!this.visible) {
+        this.addGLTFComponent("visible", {
+          visible: this.visible
+        });
+      }
+    }
+
+    addGLTFComponent(name, props) {
+      if (!this.userData.gltfExtensions || !this.userData.gltfExtensions.HUBS_components) {
+        this.userData.gltfExtensions = {
+          HUBS_components: {}
+        };
+      }
+
+      if (props !== undefined && typeof props !== "object") {
+        throw new Error("glTF component props must be an object or undefined");
+      }
+
+      const componentProps = {};
+
+      for (const key in props) {
+        const value = props[key];
+
+        if (value instanceof THREE.Color) {
+          componentProps[key] = serializeColor(value);
+        } else {
+          componentProps[key] = value;
+        }
+      }
+
+      this.userData.gltfExtensions.HUBS_components[name] = props;
+    }
+
+    replaceObject(replacementObject) {
+      replacementObject = replacementObject || new THREE.Object3D().copy(this, false);
+
+      if (this.userData.gltfExtensions && this.userData.gltfExtensions.HUBS_components) {
+        replacementObject.userData.gltfExtensions.HUBS_components = this.userData.gltfExtensions.HUBS_components;
+      }
+
+      this.parent.add(replacementObject);
+      this.parent.remove(this);
+    }
 
     computeStaticMode() {
       return computeStaticMode(this);

--- a/src/client/editor/nodes/FloorPlanNode.js
+++ b/src/client/editor/nodes/FloorPlanNode.js
@@ -249,7 +249,6 @@ export default class FloorPlanNode extends EditorNodeMixin(FloorPlan) {
   }
 
   onSelect() {
-    console.log("onSelect navMesh", this.navMesh);
     if (this.navMesh) {
       this.navMesh.visible = true;
     }

--- a/src/client/editor/nodes/FloorPlanNode.js
+++ b/src/client/editor/nodes/FloorPlanNode.js
@@ -5,15 +5,95 @@ import Recast from "../recast/recast.js";
 import ModelNode from "./ModelNode";
 import GroundPlaneNode from "./GroundPlaneNode";
 import absoluteToRelativeURL from "../utils/absoluteToRelativeURL";
+import BoxColliderNode from "./BoxColliderNode";
 
 let recast = null;
 
-function generateNavMesh(positions, indices, cellSize) {
+function mergeMeshGeometries(meshes) {
+  const geometries = [];
+
+  for (const mesh of meshes) {
+    let geometry = mesh.geometry;
+    let attributes = geometry.attributes;
+
+    if (!geometry.isBufferGeometry) {
+      geometry = new THREE.BufferGeometry().fromGeometry(geometry);
+      attributes = geometry.attributes;
+    }
+
+    if (!attributes.position || attributes.position.itemSize !== 3) return;
+
+    if (geometry.index) geometry = geometry.toNonIndexed();
+
+    const cloneGeometry = new THREE.BufferGeometry();
+    cloneGeometry.addAttribute("position", geometry.attributes.position.clone());
+    cloneGeometry.applyMatrix(mesh.matrixWorld);
+    geometry = cloneGeometry;
+
+    geometries.push(geometry);
+  }
+
+  if (geometries.length === 0) {
+    return new THREE.BufferGeometry();
+  }
+
+  const geometry = THREE.BufferGeometryUtils.mergeBufferGeometries(geometries);
+
+  const flippedGeometry = geometry.clone();
+
+  const positions = flippedGeometry.attributes.position.array;
+  for (let i = 0; i < positions.length; i += 9) {
+    const x0 = positions[i];
+    const y0 = positions[i + 1];
+    const z0 = positions[i + 2];
+    const offset = 6;
+    positions[i] = positions[i + offset];
+    positions[i + 1] = positions[i + offset + 1];
+    positions[i + 2] = positions[i + offset + 2];
+    positions[i + offset] = x0;
+    positions[i + offset + 1] = y0;
+    positions[i + offset + 2] = z0;
+  }
+
+  return THREE.BufferGeometryUtils.mergeBufferGeometries([geometry, flippedGeometry]);
+}
+
+function generateNavGeometry(geometry) {
   if (!recast) {
     throw new Error("Recast module unavailable or not yet loaded.");
   }
+
+  if (!geometry.attributes.position || geometry.attributes.position.count === 0) {
+    const emptyGeometry = new THREE.BufferGeometry();
+    emptyGeometry.setIndex([]);
+    emptyGeometry.addAttribute("position", new THREE.Float32BufferAttribute([], 3));
+    return emptyGeometry;
+  }
+
+  const box = new THREE.Box3().setFromBufferAttribute(geometry.attributes.position);
+  const size = new THREE.Vector3();
+  box.getSize(size);
+  if (Math.max(size.x, size.y, size.z) > 2000) {
+    throw new Error(
+      `Scene is too large (${size.x.toFixed(3)} x ${size.y.toFixed(3)} x ${size.z.toFixed(3)}) ` +
+        `to generate a floor plan.\n` +
+        `You can un-check the "walkable" checkbox on models to exclude them from the floor plan.`
+    );
+  }
+
+  const positions = geometry.attributes.position.array;
+  const indices = new Int32Array(positions.length / 3);
+  for (let i = 0; i < indices.length; i++) {
+    indices[i] = i;
+  }
+
   recast.loadArray(positions, indices);
-  const objMesh = recast.build(
+
+  const area = size.x * size.z;
+  // Tuned to produce cell sizes from ~0.5 to ~1.5 for areas from ~200 to ~350,000.
+  const cellSize = Math.pow(area, 1 / 3) / 50;
+
+  const objMeshStr = recast.build(
     cellSize,
     0.1, // cellHeight
     1.0, // agentHeight
@@ -28,37 +108,51 @@ function generateNavMesh(positions, indices, cellSize) {
     16, //detailSampleDist
     1 // detailSampleMaxError
   );
+
+  const navPositions = [];
+  const navIndices = [];
+
   // TODO; Dumb that recast returns an OBJ formatted string. We should have it return an array.
-  return objMesh.split("@").reduce(
-    (acc, line) => {
-      line = line.trim();
-      if (line.length === 0) return acc;
-      const values = line.split(" ");
-      if (values[0] === "v") {
-        acc.navPosition[acc.navPosition.length] = Number(values[1]);
-        acc.navPosition[acc.navPosition.length] = Number(values[2]);
-        acc.navPosition[acc.navPosition.length] = Number(values[3]);
-      } else if (values[0] === "f") {
-        acc.navIndex[acc.navIndex.length] = Number(values[1]) - 1;
-        acc.navIndex[acc.navIndex.length] = Number(values[2]) - 1;
-        acc.navIndex[acc.navIndex.length] = Number(values[3]) - 1;
-      } else {
-        throw new Error(`Invalid objMesh line "${line}"`);
-      }
-      return acc;
-    },
-    { navPosition: [], navIndex: [] }
-  );
+  const objLines = objMeshStr.split("@");
+
+  for (const line of objLines) {
+    const trimmedLine = line.trim();
+
+    if (trimmedLine.length === 0) {
+      continue;
+    }
+
+    const values = trimmedLine.split(" ");
+
+    if (values[0] === "v") {
+      navPositions.push(Number(values[1]));
+      navPositions.push(Number(values[2]));
+      navPositions.push(Number(values[3]));
+    } else if (values[0] === "f") {
+      navIndices.push(Number(values[1] - 1));
+      navIndices.push(Number(values[2] - 1));
+      navIndices.push(Number(values[3] - 1));
+    } else {
+      throw new Error(`Invalid objMesh line "${line}"`);
+    }
+  }
+
+  const navGeometry = new THREE.BufferGeometry();
+  navGeometry.setIndex(navIndices);
+  navGeometry.addAttribute("position", new THREE.Float32BufferAttribute(navPositions, 3));
+
+  return navGeometry;
 }
 
 async function yieldFor(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function generateHeightfield(mesh) {
-  mesh.geometry.computeBoundingBox();
+async function generateHeightfield(geometry) {
+  geometry.computeBoundingBox();
   const size = new THREE.Vector3();
-  mesh.geometry.boundingBox.getSize(size);
+  geometry.boundingBox.getSize(size);
+  const heightfieldMesh = new THREE.Mesh(geometry);
 
   const maxSide = Math.max(size.x, size.z);
   const distance = Math.max(0.25, Math.pow(maxSide, 1 / 2) / 10);
@@ -81,7 +175,7 @@ async function generateHeightfield(mesh) {
       position.set(offsetX + x * distance, size.y / 2, offsetZ + z * distance);
       raycaster.set(position, down);
       intersections.length = 0;
-      raycaster.intersectObject(mesh, false, intersections);
+      raycaster.intersectObject(heightfieldMesh, false, intersections);
       let val;
       if (intersections.length) {
         val = -intersections[0].distance + size.y / 2;
@@ -155,130 +249,83 @@ export default class FloorPlanNode extends EditorNodeMixin(FloorPlan) {
   }
 
   onSelect() {
-    this.visible = true;
+    console.log("onSelect navMesh", this.navMesh);
+    if (this.navMesh) {
+      this.navMesh.visible = true;
+    }
   }
 
   onDeselect() {
-    this.visible = false;
+    if (this.navMesh) {
+      this.navMesh.visible = false;
+    }
   }
 
   async generate(scene) {
-    const geometries = [];
+    const collidableMeshes = [];
+    const walkableMeshes = [];
 
     const modelNodes = scene.getNodesByType(ModelNode);
-
-    const meshes = [];
 
     for (const node of modelNodes) {
       const model = node.model;
 
-      if (!node.includeInFloorPlan || !model) {
+      if (!model || !(node.collidable || node.walkable)) {
         continue;
       }
 
       model.traverse(child => {
         if (child.isMesh) {
-          meshes.push(child);
+          if (node.collidable) {
+            collidableMeshes.push(child);
+          }
+
+          if (node.walkable) {
+            walkableMeshes.push(child);
+          }
         }
       });
     }
 
-    for (const mesh of meshes) {
-      let geometry = mesh.geometry;
-      let attributes = geometry.attributes;
+    const boxColliderNodes = scene.getNodesByType(BoxColliderNode);
 
-      if (!geometry.isBufferGeometry) {
-        geometry = new THREE.BufferGeometry().fromGeometry(geometry);
-        attributes = geometry.attributes;
+    for (const node of boxColliderNodes) {
+      if (node.walkable) {
+        const helperMesh = node.helper.object;
+        const boxColliderMesh = new THREE.Mesh(helperMesh.geometry, new THREE.MeshBasicMaterial());
+        boxColliderMesh.applyMatrix(node.matrixWorld);
+        boxColliderMesh.updateMatrixWorld();
+        walkableMeshes.push(boxColliderMesh);
       }
-
-      if (!attributes.position || attributes.position.itemSize !== 3) return;
-
-      if (geometry.index) geometry = geometry.toNonIndexed();
-
-      const cloneGeometry = new THREE.BufferGeometry();
-      cloneGeometry.addAttribute("position", geometry.attributes.position.clone());
-      cloneGeometry.applyMatrix(mesh.matrixWorld);
-      geometry = cloneGeometry;
-
-      geometries.push(geometry);
     }
 
-    const finalGeos = [];
-    let heightfield;
-
-    if (geometries.length) {
-      const geometry = THREE.BufferGeometryUtils.mergeBufferGeometries(geometries);
-
-      const flippedGeometry = geometry.clone();
-
-      const positions = flippedGeometry.attributes.position.array;
-      for (let i = 0; i < positions.length; i += 9) {
-        const x0 = positions[i];
-        const y0 = positions[i + 1];
-        const z0 = positions[i + 2];
-        const offset = 6;
-        positions[i] = positions[i + offset];
-        positions[i + 1] = positions[i + offset + 1];
-        positions[i + 2] = positions[i + offset + 2];
-        positions[i + offset] = x0;
-        positions[i + offset + 1] = y0;
-        positions[i + offset + 2] = z0;
-      }
-
-      const finalGeo = THREE.BufferGeometryUtils.mergeBufferGeometries([geometry, flippedGeometry]);
-
-      const position = finalGeo.attributes.position.array;
-      const index = new Int32Array(position.length / 3);
-      for (let i = 0; i < index.length; i++) {
-        index[i] = i;
-      }
-
-      const box = new THREE.Box3().setFromBufferAttribute(finalGeo.attributes.position);
-      const size = new THREE.Vector3();
-      box.getSize(size);
-      if (Math.max(size.x, size.y, size.z) > 2000) {
-        throw new Error(
-          `Scene is too large (${size.x.toFixed(3)} x ${size.y.toFixed(3)} x ${size.z.toFixed(3)}) ` +
-            `to generate a floor plan.\n` +
-            `You can un-check the "Include in Floor Plan" checkbox on models to exclude them from the floor plan.`
-        );
-      }
-      const area = size.x * size.z;
-      // Tuned to produce cell sizes from ~0.5 to ~1.5 for areas from ~200 to ~350,000.
-      const cellSize = Math.pow(area, 1 / 3) / 50;
-      const { navPosition, navIndex } = generateNavMesh(position, index, cellSize);
-
-      const navGeo = new THREE.BufferGeometry();
-      navGeo.setIndex(navIndex);
-      navGeo.addAttribute("position", new THREE.Float32BufferAttribute(navPosition, 3));
-
-      heightfield = await generateHeightfield(new THREE.Mesh(navGeo));
-
-      finalGeos.push(navGeo);
-    }
+    const walkableGeometry = mergeMeshGeometries(walkableMeshes);
+    const walkableNavGeometry = generateNavGeometry(walkableGeometry);
+    let finalWalkableGeometry = walkableNavGeometry;
 
     const groundPlaneNode = scene.findNodeByType(GroundPlaneNode);
 
-    if (groundPlaneNode) {
+    if (groundPlaneNode && groundPlaneNode.walkable) {
       const groundPlaneMesh = groundPlaneNode.mesh;
       const origGroundPlaneGeo = groundPlaneMesh.geometry;
       const groundPlaneGeo = new THREE.BufferGeometry();
       groundPlaneGeo.setIndex(origGroundPlaneGeo.index);
       groundPlaneGeo.addAttribute("position", origGroundPlaneGeo.attributes.position.clone());
       groundPlaneGeo.applyMatrix(groundPlaneMesh.matrixWorld);
-      finalGeos.push(groundPlaneGeo);
+      finalWalkableGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries([walkableNavGeometry, groundPlaneGeo]);
     }
 
-    if (finalGeos.length === 0) return;
+    const navMesh = new THREE.Mesh(finalWalkableGeometry, new THREE.MeshBasicMaterial({ color: 0x0000ff }));
 
-    const finalNavGeo =
-      finalGeos.length === 1 ? finalGeos[0] : THREE.BufferGeometryUtils.mergeBufferGeometries(finalGeos);
+    if (this.editor.selected !== this) {
+      navMesh.visible = false;
+    }
 
-    const navMesh = new THREE.Mesh(finalNavGeo, new THREE.MeshBasicMaterial({ color: 0x0000ff }));
-
-    this.heightfield = heightfield || null;
     this.setNavMesh(navMesh);
+
+    const heightfieldGeometry = mergeMeshGeometries(collidableMeshes);
+    const collidableNavGeometry = generateNavGeometry(heightfieldGeometry);
+    this.heightfield = await generateHeightfield(collidableNavGeometry);
 
     return this;
   }
@@ -288,6 +335,9 @@ export default class FloorPlanNode extends EditorNodeMixin(FloorPlan) {
       const { scene } = await this.editor.gltfCache.get(src);
       const navMesh = scene.getObjectByProperty("type", "Mesh");
       this.navMeshSrc = src;
+      if (this.editor.selected !== this) {
+        navMesh.visible = false;
+      }
       this.setNavMesh(navMesh);
     } catch (e) {
       console.warn("Floor plan could not be loaded. Regenerating...");
@@ -302,45 +352,30 @@ export default class FloorPlanNode extends EditorNodeMixin(FloorPlan) {
     return this;
   }
 
-  serialize(sceneUri) {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "gltf-model",
-      props: {
-        src: absoluteToRelativeURL(sceneUri, this.navMeshSrc)
-      }
-    });
-
-    json.components.push({
-      name: "nav-mesh",
-      props: {}
-    });
-
-    if (this.heightfield) {
-      json.components.push({
-        name: "heightfield",
-        props: this.heightfield
-      });
-    }
-
-    return json;
-  }
-
-  prepareForExport() {
-    const material = this.navMesh.material;
-    material.transparent = true;
-    material.opacity = 0;
-
-    this.userData.gltfExtensions = {
-      HUBS_components: {
-        visible: { visible: false },
-        "nav-mesh": {}
-      }
+  serialize() {
+    const components = {
+      "gltf-model": {
+        src: absoluteToRelativeURL(this.editor.sceneUri, this.navMeshSrc)
+      },
+      "nav-mesh": {}
     };
 
     if (this.heightfield) {
-      this.userData.gltfExtensions.HUBS_components.heightfield = this.heightfield;
+      components.heightfield = this.heightfield;
+    }
+
+    return super.serialize(components);
+  }
+
+  prepareForExport() {
+    super.prepareForExport();
+    const material = this.navMesh.material;
+    material.transparent = true;
+    material.opacity = 0;
+    this.addGLTFComponent("visible", { visible: false });
+
+    if (this.heightfield) {
+      this.addGLTFComponent("heightfield", this.heightfield);
     }
   }
 }

--- a/src/client/editor/nodes/GroundPlaneNode.js
+++ b/src/client/editor/nodes/GroundPlaneNode.js
@@ -28,6 +28,29 @@ export default class GroundPlaneNode extends EditorNodeMixin(GroundPlane) {
   constructor(editor) {
     super(editor);
     this.walkable = true;
+    this.walkableMesh = new THREE.Mesh(new THREE.CircleBufferGeometry(1, 32), new THREE.MeshBasicMaterial());
+    this.walkableMesh.scale.set(100, 100, 100);
+    this.walkableMesh.position.y = -0.05;
+    this.walkableMesh.rotation.x = -Math.PI / 2;
+    this.walkableMesh.visible = false;
+    this.add(this.walkableMesh);
+  }
+
+  copy(source, recursive) {
+    super.copy(source, false);
+
+    if (recursive) {
+      for (const child of source.children) {
+        if (child !== this.walkableMesh) {
+          const clonedChild = child.clone();
+          this.add(clonedChild);
+        }
+      }
+    }
+
+    this.walkable = source.walkable;
+
+    return this;
   }
 
   serialize() {
@@ -51,7 +74,7 @@ export default class GroundPlaneNode extends EditorNodeMixin(GroundPlane) {
     super.prepareForExport();
 
     const groundPlaneCollider = new THREE.Object3D();
-    groundPlaneCollider.scale.set(4000, 0.01, 4000);
+    groundPlaneCollider.scale.copy(this.walkableMesh.scale.x, 0.1, this.walkableMesh.scale.z);
     groundPlaneCollider.userData.gltfExtensions = {
       HUBS_components: {
         "box-collider": {

--- a/src/client/editor/nodes/GroupNode.js
+++ b/src/client/editor/nodes/GroupNode.js
@@ -7,13 +7,8 @@ export default class GroupNode extends EditorNodeMixin(THREE.Group) {
   static nodeName = "Group";
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "group",
-      props: {}
+    return super.serialize({
+      group: {}
     });
-
-    return json;
   }
 }

--- a/src/client/editor/nodes/HemisphereLightNode.js
+++ b/src/client/editor/nodes/HemisphereLightNode.js
@@ -1,7 +1,5 @@
-import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import PhysicalHemisphereLight from "../objects/PhysicalHemisphereLight";
-import serializeColor from "../utils/serializeColor";
 
 export default class HemisphereLightNode extends EditorNodeMixin(PhysicalHemisphereLight) {
   static legacyComponentName = "hemisphere-light";
@@ -23,34 +21,22 @@ export default class HemisphereLightNode extends EditorNodeMixin(PhysicalHemisph
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "hemisphere-light",
-      props: {
-        skyColor: serializeColor(this.skyColor),
-        groundColor: serializeColor(this.groundColor),
+    return super.serialize({
+      "hemisphere-light": {
+        skyColor: this.skyColor,
+        groundColor: this.groundColor,
         intensity: this.intensity
       }
     });
-
-    return json;
   }
 
   prepareForExport() {
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        "hemisphere-light": {
-          skyColor: serializeColor(this.skyColor),
-          groundColor: serializeColor(this.groundColor),
-          intensity: this.intensity
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    super.prepareForExport();
+    this.addGLTFComponent("hemisphere-light", {
+      skyColor: this.skyColor,
+      groundColor: this.groundColor,
+      intensity: this.intensity
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/nodes/ImageNode.js
+++ b/src/client/editor/nodes/ImageNode.js
@@ -1,4 +1,3 @@
-import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import Image from "../objects/Image";
 
@@ -55,35 +54,23 @@ export default class ImageNode extends EditorNodeMixin(Image) {
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "image",
-      props: {
+    return super.serialize({
+      image: {
         src: this._canonicalUrl,
         projection: this.projection
       }
     });
-
-    return json;
   }
 
   prepareForExport() {
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        image: {
-          src: this._canonicalUrl,
-          projection: this.projection
-        },
-        networked: {
-          id: this.uuid
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    super.prepareForExport();
+    this.addGLTFComponent("image", {
+      src: this._canonicalUrl,
+      projection: this.projection
+    });
+    this.addGLTFComponent("networked", {
+      id: this.uuid
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/nodes/ModelNode.js
+++ b/src/client/editor/nodes/ModelNode.js
@@ -7,11 +7,7 @@ import absoluteToRelativeURL from "../utils/absoluteToRelativeURL";
 export default class ModelNode extends EditorNodeMixin(Model) {
   static nodeName = "Model";
 
-  static shouldDeserialize(entityJson) {
-    const gltfModelComponent = entityJson.components.find(c => c.name === "gltf-model");
-    const navMeshComponent = entityJson.components.find(c => c.name === "nav-mesh");
-    return gltfModelComponent && !navMeshComponent;
-  }
+  static legacyComponentName = "gltf-model";
 
   static async deserialize(editor, json) {
     const node = await super.deserialize(editor, json);

--- a/src/client/editor/nodes/ModelNode.js
+++ b/src/client/editor/nodes/ModelNode.js
@@ -16,7 +16,7 @@ export default class ModelNode extends EditorNodeMixin(Model) {
   static async deserialize(editor, json) {
     const node = await super.deserialize(editor, json);
 
-    const { src, attribution, includeInFloorPlan, origin } = json.components.find(c => c.name === "gltf-model").props;
+    const { src, attribution, origin } = json.components.find(c => c.name === "gltf-model").props;
 
     let absoluteURL = new URL(src, editor.sceneUri).href;
 
@@ -34,7 +34,8 @@ export default class ModelNode extends EditorNodeMixin(Model) {
       node.attribution = attribution;
     }
 
-    node.includeInFloorPlan = includeInFloorPlan === undefined ? true : includeInFloorPlan;
+    node.collidable = !!json.components.find(c => c.name === "collidable");
+    node.walkable = !!json.components.find(c => c.name === "walkable");
 
     const loopAnimationComponent = json.components.find(c => c.name === "loop-animation");
 
@@ -55,8 +56,9 @@ export default class ModelNode extends EditorNodeMixin(Model) {
   constructor(editor) {
     super(editor);
     this.attribution = null;
-    this.includeInFloorPlan = true;
     this._canonicalUrl = null;
+    this.collidable = true;
+    this.walkable = true;
   }
 
   // Overrides Model's src property and stores the original (non-resolved) url.
@@ -130,36 +132,33 @@ export default class ModelNode extends EditorNodeMixin(Model) {
     }
   }
 
-  serialize(sceneUri) {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "gltf-model",
-      props: {
-        src: absoluteToRelativeURL(sceneUri, this._canonicalUrl),
-        attribution: this.attribution,
-        includeInFloorPlan: this.includeInFloorPlan
-      }
-    });
-
-    json.components.push({
-      name: "shadow",
-      props: {
+  serialize() {
+    const components = {
+      "gltf-model": {
+        src: absoluteToRelativeURL(this.editor.sceneUri, this._canonicalUrl),
+        attribution: this.attribution
+      },
+      shadow: {
         cast: this.castShadow,
         receive: this.receiveShadow
       }
-    });
+    };
 
     if (this.clipActions.length > 0) {
-      json.components.push({
-        name: "loop-animation",
-        props: {
-          clip: this.clipActions[0].getClip().name
-        }
-      });
+      components["loop-animation"] = {
+        clip: this.clipActions[0].getClip().name
+      };
     }
 
-    return json;
+    if (this.collidable) {
+      components.collidable = {};
+    }
+
+    if (this.walkable) {
+      components.walkable = {};
+    }
+
+    return super.serialize(components);
   }
 
   copy(source, recursive) {
@@ -167,25 +166,23 @@ export default class ModelNode extends EditorNodeMixin(Model) {
     this.updateStaticModes();
     this._canonicalUrl = source._canonicalUrl;
     this.attribution = source.attribution;
-    this.includeInFloorPlan = source.includeInFloorPlan;
+    this.collidable = source.collidable;
+    this.walkable = source.walkable;
     return this;
   }
 
   prepareForExport() {
-    this.userData.gltfExtensions = {
-      HUBS_components: {
-        shadow: {
-          cast: this.castShadow,
-          receive: this.receiveShadow
-        }
-      }
-    };
+    super.prepareForExport();
+    this.addGLTFComponent("shadow", {
+      cast: this.castShadow,
+      receive: this.receiveShadow
+    });
 
     // TODO: Support exporting more than one active clip.
     if (this.clipActions.length > 0) {
-      this.userData.gltfExtensions.HUBS_components["loop-animation"] = {
+      this.addGLTFComponent("loop-animation", {
         clip: this.clipActions[0].getClip().name
-      };
+      });
     }
   }
 }

--- a/src/client/editor/nodes/PointLightNode.js
+++ b/src/client/editor/nodes/PointLightNode.js
@@ -1,8 +1,6 @@
-import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import PhysicalPointLight from "../objects/PhysicalPointLight";
 import SpokePointLightHelper from "../helpers/SpokePointLightHelper";
-import serializeColor from "../utils/serializeColor";
 
 export default class PointLightNode extends EditorNodeMixin(PhysicalPointLight) {
   static legacyComponentName = "point-light";
@@ -70,12 +68,9 @@ export default class PointLightNode extends EditorNodeMixin(PhysicalPointLight) 
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "point-light",
-      props: {
-        color: serializeColor(this.color),
+    return super.serialize({
+      "point-light": {
+        color: this.color,
         intensity: this.intensity,
         range: this.range,
         castShadow: this.castShadow,
@@ -84,30 +79,20 @@ export default class PointLightNode extends EditorNodeMixin(PhysicalPointLight) 
         shadowRadius: this.shadowRadius
       }
     });
-
-    return json;
   }
 
   prepareForExport() {
+    super.prepareForExport();
     this.remove(this.helper);
-
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        "point-light": {
-          color: serializeColor(this.color),
-          intensity: this.intensity,
-          range: this.range,
-          castShadow: this.castShadow,
-          shadowMapResolution: this.shadowMapResolution.toArray(),
-          shadowBias: this.shadowBias,
-          shadowRadius: this.shadowRadius
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    this.addGLTFComponent("point-light", {
+      color: this.color,
+      intensity: this.intensity,
+      range: this.range,
+      castShadow: this.castShadow,
+      shadowMapResolution: this.shadowMapResolution.toArray(),
+      shadowBias: this.shadowBias,
+      shadowRadius: this.shadowRadius
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/nodes/SceneNode.js
+++ b/src/client/editor/nodes/SceneNode.js
@@ -65,6 +65,15 @@ function migrateV2ToV3(json) {
         props: {}
       });
     }
+
+    const groundPlaneComponent = entity.components.find(c => c.name === "ground-plane");
+
+    if (groundPlaneComponent) {
+      entity.components.push({
+        name: "walkable",
+        props: {}
+      });
+    }
   }
 
   return json;

--- a/src/client/editor/nodes/SceneNode.js
+++ b/src/client/editor/nodes/SceneNode.js
@@ -53,8 +53,9 @@ function migrateV2ToV3(json) {
     });
 
     const modelComponent = entity.components.find(c => c.name === "gltf-model");
+    const navMeshComponent = entity.components.find(c => c.name === "nav-mesh");
 
-    if (modelComponent && modelComponent.props.includeInFloorPlan) {
+    if (!navMeshComponent && modelComponent && modelComponent.props.includeInFloorPlan) {
       entity.components.push({
         name: "collidable",
         props: {}
@@ -73,6 +74,24 @@ function migrateV2ToV3(json) {
         name: "walkable",
         props: {}
       });
+    }
+
+    if (modelComponent && navMeshComponent) {
+      entity.components = [
+        {
+          name: "floor-plan",
+          props: {
+            autoCellSize: true,
+            cellSize: 1,
+            cellHeight: 0.1,
+            agentHeight: 1.0,
+            agentRadius: 0.0001,
+            agentMaxClimb: 0.5,
+            agentMaxSlope: 45,
+            regionMinSize: 4
+          }
+        }
+      ];
     }
   }
 

--- a/src/client/editor/nodes/SkyboxNode.js
+++ b/src/client/editor/nodes/SkyboxNode.js
@@ -75,11 +75,8 @@ export default class SkyboxNode extends EditorNodeMixin(Sky) {
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "skybox",
-      props: {
+    return super.serialize({
+      skybox: {
         turbidity: this.turbidity,
         rayleigh: this.rayleigh,
         luminance: this.luminance,
@@ -90,29 +87,20 @@ export default class SkyboxNode extends EditorNodeMixin(Sky) {
         distance: this.distance
       }
     });
-
-    return json;
   }
 
   prepareForExport() {
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        skybox: {
-          turbidity: this.turbidity,
-          rayleigh: this.rayleigh,
-          luminance: this.luminance,
-          mieCoefficient: this.mieCoefficient,
-          mieDirectionalG: this.mieDirectionalG,
-          inclination: this.inclination,
-          azimuth: this.azimuth,
-          distance: this.distance
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    super.prepareForExport();
+    this.addGLTFComponent("skybox", {
+      turbidity: this.turbidity,
+      rayleigh: this.rayleigh,
+      luminance: this.luminance,
+      mieCoefficient: this.mieCoefficient,
+      mieDirectionalG: this.mieDirectionalG,
+      inclination: this.inclination,
+      azimuth: this.azimuth,
+      distance: this.distance
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/nodes/SpawnPointNode.js
+++ b/src/client/editor/nodes/SpawnPointNode.js
@@ -48,23 +48,14 @@ export default class SpawnPointNode extends EditorNodeMixin(THREE.Object3D) {
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "spawn-point",
-      props: {}
+    return super.serialize({
+      "spawn-point": {}
     });
-
-    return json;
   }
 
   prepareForExport() {
+    super.prepareForExport();
     this.remove(this.helper);
-
-    this.userData.gltfExtensions = {
-      HUBS_components: {
-        "spawn-point": {}
-      }
-    };
+    this.addGLTFComponent("spawn-point", {});
   }
 }

--- a/src/client/editor/nodes/SpawnerNode.js
+++ b/src/client/editor/nodes/SpawnerNode.js
@@ -1,4 +1,3 @@
-import THREE from "../../vendor/three";
 import Model from "../objects/Model";
 import EditorNodeMixin from "./EditorNodeMixin";
 import absoluteToRelativeURL from "../utils/absoluteToRelativeURL";
@@ -62,17 +61,12 @@ export default class SpawnerNode extends EditorNodeMixin(Model) {
     return this;
   }
 
-  serialize(sceneUri) {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "spawner",
-      props: {
-        src: absoluteToRelativeURL(sceneUri, this._canonicalUrl)
+  serialize() {
+    return super.serialize({
+      spawner: {
+        src: absoluteToRelativeURL(this.editor.sceneUri, this._canonicalUrl)
       }
     });
-
-    return json;
   }
 
   copy(source, recursive) {
@@ -82,17 +76,10 @@ export default class SpawnerNode extends EditorNodeMixin(Model) {
   }
 
   prepareForExport() {
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        spawner: {
-          src: this._canonicalUrl
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    super.prepareForExport();
+    this.addGLTFComponent("spawner", {
+      src: this._canonicalUrl
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/nodes/SpotLightNode.js
+++ b/src/client/editor/nodes/SpotLightNode.js
@@ -1,8 +1,6 @@
-import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import PhysicalSpotLight from "../objects/PhysicalSpotLight";
 import SpokeSpotLightHelper from "../helpers/SpokeSpotLightHelper";
-import serializeColor from "../utils/serializeColor";
 
 export default class SpotLightNode extends EditorNodeMixin(PhysicalSpotLight) {
   static legacyComponentName = "spot-light";
@@ -80,12 +78,9 @@ export default class SpotLightNode extends EditorNodeMixin(PhysicalSpotLight) {
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "spot-light",
-      props: {
-        color: serializeColor(this.color),
+    return super.serialize({
+      "spot-light": {
+        color: this.color,
         intensity: this.intensity,
         range: this.range,
         innerConeAngle: this.innerConeAngle,
@@ -96,32 +91,22 @@ export default class SpotLightNode extends EditorNodeMixin(PhysicalSpotLight) {
         shadowRadius: this.shadowRadius
       }
     });
-
-    return json;
   }
 
   prepareForExport() {
+    super.prepareForExport();
     this.remove(this.helper);
-
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        "spot-light": {
-          color: serializeColor(this.color),
-          intensity: this.intensity,
-          range: this.range,
-          innerConeAngle: this.innerConeAngle,
-          outerConeAngle: this.outerConeAngle,
-          castShadow: this.castShadow,
-          shadowMapResolution: this.shadowMapResolution.toArray(),
-          shadowBias: this.shadowBias,
-          shadowRadius: this.shadowRadius
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    this.addGLTFComponent("spot-light", {
+      color: this.color,
+      intensity: this.intensity,
+      range: this.range,
+      innerConeAngle: this.innerConeAngle,
+      outerConeAngle: this.outerConeAngle,
+      castShadow: this.castShadow,
+      shadowMapResolution: this.shadowMapResolution.toArray(),
+      shadowBias: this.shadowBias,
+      shadowRadius: this.shadowRadius
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/nodes/VideoNode.js
+++ b/src/client/editor/nodes/VideoNode.js
@@ -1,4 +1,3 @@
-import THREE from "../../vendor/three";
 import EditorNodeMixin from "./EditorNodeMixin";
 import Video from "../objects/Video";
 
@@ -94,11 +93,8 @@ export default class VideoNode extends EditorNodeMixin(Video) {
   }
 
   serialize() {
-    const json = super.serialize();
-
-    json.components.push({
-      name: "video",
-      props: {
+    return super.serialize({
+      video: {
         src: this._canonicalUrl,
         controls: this.controls,
         autoPlay: this.autoPlay,
@@ -115,38 +111,29 @@ export default class VideoNode extends EditorNodeMixin(Video) {
         projection: this.projection
       }
     });
-
-    return json;
   }
 
   prepareForExport() {
-    const replacementObject = new THREE.Object3D().copy(this, false);
-
-    replacementObject.userData.gltfExtensions = {
-      HUBS_components: {
-        video: {
-          src: this._canonicalUrl,
-          controls: this.controls,
-          autoPlay: this.autoPlay,
-          loop: this.loop,
-          audioType: this.audioType,
-          volume: this.volume,
-          distanceModel: this.distanceModel,
-          rolloffFactor: this.rolloffFactor,
-          refDistance: this.refDistance,
-          maxDistance: this.maxDistance,
-          coneInnerAngle: this.coneInnerAngle,
-          coneOuterAngle: this.coneOuterAngle,
-          coneOuterGain: this.coneOuterGain,
-          projection: this.projection
-        },
-        networked: {
-          id: this.uuid
-        }
-      }
-    };
-
-    this.parent.add(replacementObject);
-    this.parent.remove(this);
+    super.prepareForExport();
+    this.addGLTFComponent("video", {
+      src: this._canonicalUrl,
+      controls: this.controls,
+      autoPlay: this.autoPlay,
+      loop: this.loop,
+      audioType: this.audioType,
+      volume: this.volume,
+      distanceModel: this.distanceModel,
+      rolloffFactor: this.rolloffFactor,
+      refDistance: this.refDistance,
+      maxDistance: this.maxDistance,
+      coneInnerAngle: this.coneInnerAngle,
+      coneOuterAngle: this.coneOuterAngle,
+      coneOuterGain: this.coneOuterGain,
+      projection: this.projection
+    });
+    this.addGLTFComponent("networked", {
+      id: this.uuid
+    });
+    this.replaceObject();
   }
 }

--- a/src/client/editor/objects/FloorPlan.js
+++ b/src/client/editor/objects/FloorPlan.js
@@ -4,14 +4,20 @@ export default class FloorPlan extends THREE.Object3D {
   constructor() {
     super();
     this.position.y = 0.005;
-    this.visible = false;
     this.navMesh = null;
     this.heightfield = null;
   }
 
   setNavMesh(object) {
+    if (this.navMesh) {
+      this.remove(this.navMesh);
+    }
+
+    if (object) {
+      this.add(object);
+    }
+
     this.navMesh = object;
-    this.add(this.navMesh);
   }
 
   copy(source, recursive) {
@@ -24,6 +30,7 @@ export default class FloorPlan extends THREE.Object3D {
 
       if (child === source.navMesh) {
         clonedChild = child.clone();
+        clonedChild.material = child.material.clone();
         this.navMesh = clonedChild;
       } else if (recursive === true) {
         clonedChild = child.clone();

--- a/src/client/ui/App.js
+++ b/src/client/ui/App.js
@@ -201,6 +201,7 @@ class App extends Component {
   };
 
   componentDidMount() {
+    this.props.editor.project.watch();
     this.props.editor.signals.windowResize.dispatch();
     this.props.editor.signals.sceneModified.add(this.onSceneModified);
     this.props.editor.signals.editorError.add(this.onEditorError);

--- a/src/client/ui/App.js
+++ b/src/client/ui/App.js
@@ -167,10 +167,6 @@ class App extends Component {
             action: e => this.onExportScene(e, true)
           },
           {
-            name: "Generate Floor Plan",
-            action: e => this.onGenerateFloorPlan(e)
-          },
-          {
             name: "Open Scenes Folder...",
             action: () => this.props.editor.project.openProjectDirectory()
           }
@@ -338,26 +334,6 @@ class App extends Component {
     }
 
     this.onExportSceneDialog(glb);
-  };
-
-  onGenerateFloorPlan = async e => {
-    e.preventDefault();
-
-    this.showDialog(ProgressDialog, {
-      title: "Generating Floor Plan",
-      message: "Generating floor plan..."
-    });
-
-    try {
-      await this.props.editor.generateFloorPlan();
-      this.hideDialog();
-    } catch (e) {
-      console.error(e);
-      this.showDialog(ErrorDialog, {
-        title: "Error Generating Floor Plan",
-        message: e.message || "There was an unknown error."
-      });
-    }
   };
 
   onTranslateTool = e => {

--- a/src/client/ui/properties/BoxColliderNodeEditor.js
+++ b/src/client/ui/properties/BoxColliderNodeEditor.js
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import NodeEditor from "./NodeEditor";
+import InputGroup from "../inputs/InputGroup";
+import BooleanInput from "../inputs/BooleanInput";
 
 export default class BoxColliderNodeEditor extends Component {
   static propTypes = {
@@ -10,12 +12,20 @@ export default class BoxColliderNodeEditor extends Component {
 
   static iconClassName = "fa-hand-paper";
 
+  onChangeWalkable = walkable => {
+    this.props.editor.setNodeProperty(this.props.node, "walkable", walkable);
+  };
+
   render() {
     return (
       <NodeEditor
         {...this.props}
         description="An invisible box that objects will bounce off of or rest on top of.\nWithout colliders, objects will fall through floors and go through walls."
-      />
+      >
+        <InputGroup name="Walkable">
+          <BooleanInput value={this.props.node.walkable} onChange={this.onChangeWalkable} />
+        </InputGroup>
+      </NodeEditor>
     );
   }
 }

--- a/src/client/ui/properties/FloorPlanNodeEditor.js
+++ b/src/client/ui/properties/FloorPlanNodeEditor.js
@@ -1,16 +1,95 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import NodeEditor from "./NodeEditor";
+import InputGroup from "../inputs/InputGroup";
+import BooleanInput from "../inputs/BooleanInput";
+import NumericInput from "../inputs/NumericInput";
+import Button from "../inputs/Button";
+import ProgressDialog from "../dialogs/ProgressDialog";
+import ErrorDialog from "../dialogs/ErrorDialog";
+import { withDialog } from "../contexts/DialogContext";
+import styles from "./FloorPlanNodeEditor.scss";
 
-export default class FloorPlanNodeEditor extends Component {
+class FloorPlanNodeEditor extends Component {
   static propTypes = {
+    hideDialog: PropTypes.func.isRequired,
+    showDialog: PropTypes.func.isRequired,
     editor: PropTypes.object,
     node: PropTypes.object
   };
 
   static iconClassName = "fa-shoe-prints";
 
+  constructor(props) {
+    super(props);
+    const createPropSetter = propName => value => this.props.editor.setNodeProperty(this.props.node, propName, value);
+    this.onChangeAutoCellSize = createPropSetter("autoCellSize");
+    this.onChangeCellSize = createPropSetter("cellSize");
+    this.onChangeCellHeight = createPropSetter("cellHeight");
+    this.onChangeAgentHeight = createPropSetter("agentHeight");
+    this.onChangeAgentRadius = createPropSetter("agentRadius");
+    this.onChangeAgentMaxClimb = createPropSetter("agentMaxClimb");
+    this.onChangeAgentMaxSlope = createPropSetter("agentMaxSlope");
+    this.onChangeRegionMinSize = createPropSetter("regionMinSize");
+  }
+
+  onRegenerate = async () => {
+    this.props.showDialog(ProgressDialog, {
+      title: "Generating Floor Plan",
+      message: "Generating floor plan..."
+    });
+
+    try {
+      await this.props.node.generate();
+      this.props.hideDialog();
+    } catch (e) {
+      console.error(e);
+      this.props.showDialog(ErrorDialog, {
+        title: "Error Generating Floor Plan",
+        message: e.message || "There was an unknown error."
+      });
+    }
+  };
+
   render() {
-    return <NodeEditor {...this.props} description="Sets the walkable surface area in your scene." />;
+    const node = this.props.node;
+
+    return (
+      <NodeEditor {...this.props} description="Sets the walkable surface area in your scene.">
+        <InputGroup name="Auto Cell Size">
+          <BooleanInput value={node.autoCellSize} onChange={this.onChangeAutoCellSize} />
+        </InputGroup>
+        {!node.autoCellSize && (
+          <InputGroup name="Cell Size">
+            <NumericInput value={node.cellSize} precision={0.0001} onChange={this.onChangeCellSize} />
+          </InputGroup>
+        )}
+        <InputGroup name="Cell Height">
+          <NumericInput value={node.cellHeight} onChange={this.onChangeCellHeight} />
+        </InputGroup>
+        <InputGroup name="Agent Height">
+          <NumericInput value={node.agentHeight} onChange={this.onChangeAgentHeight} />
+        </InputGroup>
+        <InputGroup name="Agent Radius">
+          <NumericInput value={node.agentRadius} onChange={this.onChangeAgentRadius} />
+        </InputGroup>
+        <InputGroup name="Maximum Step Height">
+          <NumericInput value={node.agentMaxClimb} onChange={this.onChangeAgentMaxClimb} />
+        </InputGroup>
+        <InputGroup name="Maximum Slope">
+          <NumericInput value={node.agentMaxSlope} onChange={this.onChangeAgentMaxSlope} />
+        </InputGroup>
+        <InputGroup name="Minimum Region Area">
+          <NumericInput value={node.regionMinSize} onChange={this.onChangeRegionMinSize} />
+        </InputGroup>
+        <Button className={styles.regenerateButton} onClick={this.onRegenerate}>
+          Regenerate
+        </Button>
+      </NodeEditor>
+    );
   }
 }
+
+const FloorPlanNodeEditorContainer = withDialog(FloorPlanNodeEditor);
+FloorPlanNodeEditorContainer.iconClassName = FloorPlanNodeEditor.iconClassName;
+export default FloorPlanNodeEditorContainer;

--- a/src/client/ui/properties/FloorPlanNodeEditor.scss
+++ b/src/client/ui/properties/FloorPlanNodeEditor.scss
@@ -1,0 +1,5 @@
+:local(.regenerateButton) {
+  align-self: center;
+  justify-content: center;
+  width: 200px;
+}

--- a/src/client/ui/properties/GroundPlaneNodeEditor.js
+++ b/src/client/ui/properties/GroundPlaneNodeEditor.js
@@ -21,6 +21,10 @@ export default class GroundPlaneNodeEditor extends Component {
     this.props.editor.setNodeProperty(this.props.node, "receiveShadow", receiveShadow);
   };
 
+  onChangeWalkable = walkable => {
+    this.props.editor.setNodeProperty(this.props.node, "walkable", walkable);
+  };
+
   render() {
     const node = this.props.node;
 
@@ -31,6 +35,9 @@ export default class GroundPlaneNodeEditor extends Component {
         </InputGroup>
         <InputGroup name="Receive Shadow">
           <BooleanInput value={node.receiveShadow} onChange={this.onChangeReceiveShadow} />
+        </InputGroup>
+        <InputGroup name="Walkable">
+          <BooleanInput value={this.props.node.walkable} onChange={this.onChangeWalkable} />
         </InputGroup>
       </NodeEditor>
     );

--- a/src/client/ui/properties/ModelNodeEditor.js
+++ b/src/client/ui/properties/ModelNodeEditor.js
@@ -17,8 +17,12 @@ export default class ModelNodeEditor extends Component {
     this.props.editor.setNodeProperty(this.props.node, "activeClipName", activeClipName);
   };
 
-  onChangeIncludeInFloorPlan = includeInFloorPlan => {
-    this.props.editor.setNodeProperty(this.props.node, "includeInFloorPlan", includeInFloorPlan);
+  onChangeCollidable = collidable => {
+    this.props.editor.setNodeProperty(this.props.node, "collidable", collidable);
+  };
+
+  onChangeWalkable = walkable => {
+    this.props.editor.setNodeProperty(this.props.node, "walkable", walkable);
   };
 
   onChangeCastShadow = castShadow => {
@@ -40,8 +44,11 @@ export default class ModelNodeEditor extends Component {
         <InputGroup name="Loop Animation">
           <SelectInput options={clipOptions} value={activeClipName} onChange={this.onChangeAnimation} />
         </InputGroup>
-        <InputGroup name="Include in Floor Plan">
-          <BooleanInput value={node.includeInFloorPlan} onChange={this.onChangeIncludeInFloorPlan} />
+        <InputGroup name="Collidable">
+          <BooleanInput value={node.collidable} onChange={this.onChangeCollidable} />
+        </InputGroup>
+        <InputGroup name="Walkable">
+          <BooleanInput value={node.walkable} onChange={this.onChangeWalkable} />
         </InputGroup>
         <InputGroup name="Cast Shadow">
           <BooleanInput value={node.castShadow} onChange={this.onChangeCastShadow} />

--- a/src/client/ui/properties/NodeEditor.js
+++ b/src/client/ui/properties/NodeEditor.js
@@ -4,6 +4,8 @@ import styles from "./PropertiesPanelContainer.scss";
 import PropertyGroup from "./PropertyGroup";
 import TransformPropertyGroup from "./TransformPropertyGroup";
 import NameInputGroup from "./NameInputGroup";
+import InputGroup from "../inputs/InputGroup";
+import BooleanInput from "../inputs/BooleanInput";
 
 export default class NodeEditor extends Component {
   static propTypes = {
@@ -19,6 +21,10 @@ export default class NodeEditor extends Component {
     hideTransform: false
   };
 
+  onChangeVisible = value => {
+    this.props.editor.setNodeProperty(this.props.node, "visible", value);
+  };
+
   render() {
     const { node, description, editor, children } = this.props;
 
@@ -27,6 +33,9 @@ export default class NodeEditor extends Component {
         <div className={styles.propertiesHeader}>
           <div className={styles.propertiesPanelTopBar}>
             <NameInputGroup node={node} editor={editor} />
+            <InputGroup name="Visible" className={styles.visibleInputGroup}>
+              <BooleanInput value={node.visible} onChange={this.onChangeVisible} />
+            </InputGroup>
           </div>
           {!node.hideTransform && <TransformPropertyGroup node={node} editor={editor} />}
         </div>

--- a/src/client/ui/properties/NodeEditor.js
+++ b/src/client/ui/properties/NodeEditor.js
@@ -33,9 +33,11 @@ export default class NodeEditor extends Component {
         <div className={styles.propertiesHeader}>
           <div className={styles.propertiesPanelTopBar}>
             <NameInputGroup node={node} editor={editor} />
-            <InputGroup name="Visible" className={styles.visibleInputGroup}>
-              <BooleanInput value={node.visible} onChange={this.onChangeVisible} />
-            </InputGroup>
+            {node.nodeName !== "Scene" && (
+              <InputGroup name="Visible" className={styles.visibleInputGroup}>
+                <BooleanInput value={node.visible} onChange={this.onChangeVisible} />
+              </InputGroup>
+            )}
           </div>
           {!node.hideTransform && <TransformPropertyGroup node={node} editor={editor} />}
         </div>

--- a/src/client/ui/properties/PropertiesPanelContainer.scss
+++ b/src/client/ui/properties/PropertiesPanelContainer.scss
@@ -37,6 +37,16 @@
   padding: 8px 0;
 }
 
+:local(.visibleInputGroup) {
+  display: flex;
+  flex: 0;
+  
+  & > label {
+    width: auto !important;
+    padding-right: 8px;
+  }
+}
+
 :local(.topBarName) {
   label {
     width: auto !important;

--- a/src/client/ui/properties/TransformPropertyGroup.js
+++ b/src/client/ui/properties/TransformPropertyGroup.js
@@ -4,6 +4,7 @@ import PropertyGroup from "./PropertyGroup";
 import InputGroup from "../inputs/InputGroup";
 import Vector3Input from "../inputs/Vector3Input";
 import EulerInput from "../inputs/EulerInput";
+import BooleanInput from "../inputs/BooleanInput";
 
 export default class TransformPropertyGroup extends Component {
   static propTypes = {
@@ -21,10 +22,12 @@ export default class TransformPropertyGroup extends Component {
 
   componentDidMount() {
     this.props.editor.signals.transformChanged.add(this.onTransformChanged);
+    this.props.editor.signals.objectChanged.add(this.onTransformChanged);
   }
 
   componentWillUnmount() {
     this.props.editor.signals.transformChanged.remove(this.onTransformChanged);
+    this.props.editor.signals.objectChanged.remove(this.onTransformChanged);
   }
 
   onTransformChanged = () => {
@@ -43,6 +46,10 @@ export default class TransformPropertyGroup extends Component {
     this.props.editor.setNodeProperty(this.props.node, "scale", value);
   };
 
+  onChangeVisible = value => {
+    this.props.editor.setNodeProperty(this.props.node, "visible", value);
+  };
+
   render() {
     const { node } = this.props;
 
@@ -56,6 +63,9 @@ export default class TransformPropertyGroup extends Component {
         </InputGroup>
         <InputGroup name="Scale">
           <Vector3Input uniformScaling value={node.scale} onChange={this.onChangeScale} />
+        </InputGroup>
+        <InputGroup name="Visible">
+          <BooleanInput value={node.visible} onChange={this.onChangeVisible} />
         </InputGroup>
       </PropertyGroup>
     );

--- a/src/client/ui/properties/TransformPropertyGroup.js
+++ b/src/client/ui/properties/TransformPropertyGroup.js
@@ -4,7 +4,6 @@ import PropertyGroup from "./PropertyGroup";
 import InputGroup from "../inputs/InputGroup";
 import Vector3Input from "../inputs/Vector3Input";
 import EulerInput from "../inputs/EulerInput";
-import BooleanInput from "../inputs/BooleanInput";
 
 export default class TransformPropertyGroup extends Component {
   static propTypes = {
@@ -46,10 +45,6 @@ export default class TransformPropertyGroup extends Component {
     this.props.editor.setNodeProperty(this.props.node, "scale", value);
   };
 
-  onChangeVisible = value => {
-    this.props.editor.setNodeProperty(this.props.node, "visible", value);
-  };
-
   render() {
     const { node } = this.props;
 
@@ -63,9 +58,6 @@ export default class TransformPropertyGroup extends Component {
         </InputGroup>
         <InputGroup name="Scale">
           <Vector3Input uniformScaling value={node.scale} onChange={this.onChangeScale} />
-        </InputGroup>
-        <InputGroup name="Visible">
-          <BooleanInput value={node.visible} onChange={this.onChangeVisible} />
         </InputGroup>
       </PropertyGroup>
     );

--- a/src/client/ui/viewport/AddNodeActionButtons.js
+++ b/src/client/ui/viewport/AddNodeActionButtons.js
@@ -37,6 +37,8 @@ import ImageNode from "../../editor/nodes/ImageNode";
 import VideoNode from "../../editor/nodes/VideoNode";
 import SpawnerNode from "../../editor/nodes/SpawnerNode";
 import SpawnerNodeEditor from "../properties/SpawnerNodeEditor";
+import FloorPlanNode from "../../editor/nodes/FloorPlanNode";
+import FloorPlanNodeEditor from "../properties/FloorPlanNodeEditor";
 
 function AddButton({ label, iconClassName, onClick }) {
   return (
@@ -251,7 +253,8 @@ class AddNodeActionButtons extends Component {
   getSingletonNodeState() {
     return {
       hasSkybox: !!this.props.editor.scene.findNodeByType(SkyboxNode),
-      hasGroundPlane: !!this.props.editor.scene.findNodeByType(GroundPlaneNode)
+      hasGroundPlane: !!this.props.editor.scene.findNodeByType(GroundPlaneNode),
+      hasFloorPlan: !!this.props.editor.scene.findNodeByType(FloorPlanNode)
     };
   }
 
@@ -266,7 +269,7 @@ class AddNodeActionButtons extends Component {
       [styles.fabClosed]: !this.state.open
     };
 
-    const { open, hasSkybox, hasGroundPlane } = this.state;
+    const { open, hasSkybox, hasGroundPlane, hasFloorPlan } = this.state;
 
     return (
       <div className={styles.addNodeActionButtons}>
@@ -292,6 +295,13 @@ class AddNodeActionButtons extends Component {
                 label={GroundPlaneNode.nodeName}
                 iconClassName={GroundPlaneNodeEditor.iconClassName}
                 onClick={() => this.addNode(GroundPlaneNode)}
+              />
+            )}
+            {!hasFloorPlan && (
+              <AddButton
+                label={FloorPlanNode.nodeName}
+                iconClassName={FloorPlanNodeEditor.iconClassName}
+                onClick={() => this.addNode(FloorPlanNode)}
               />
             )}
             <AddButton

--- a/test/integration/tests/Editor.test.js
+++ b/test/integration/tests/Editor.test.js
@@ -159,7 +159,8 @@ describe("Editor", () => {
         expect(model1.src, "model1.src").to.equal(
           "https://asset-bundles-prod.reticulum.io/interactables/Ducky/DuckyMesh-438ff8e022.gltf"
         );
-        expect(model1.includeInFloorPlan, "model1.includeInFloorPlan").to.equal(true);
+        expect(model1.walkable, "model1.walkable").to.equal(true);
+        expect(model1.collidable, "model1.collidable").to.equal(true);
         expect(model1.castShadow, "model1.castShadow").to.equal(true);
         expect(model1.receiveShadow, "model1.receiveShadow").to.equal(true);
         expect(model1.animations.length, "model1.animations.length").to.equal(0);
@@ -167,7 +168,8 @@ describe("Editor", () => {
         expect(model2.name, "model2.name").to.equal("Ceiling Fan");
         expect(scene.children.indexOf(model2), "model2 index").to.equal(6);
         expect(model2.src, "model2.src").to.equal("https://sketchfab.com/models/ec2c6087d4824211abc827f2a4c2b578");
-        expect(model2.includeInFloorPlan, "model2.includeInFloorPlan").to.equal(false);
+        expect(model2.walkable, "model2.walkable").to.equal(false);
+        expect(model2.collidable, "model2.collidable").to.equal(false);
         expect(model2.castShadow, "model2.castShadow").to.equal(false);
         expect(model2.receiveShadow, "model2.receiveShadow").to.equal(false);
         expect(model2.animations.length, "model2.animations.length").to.equal(1);


### PR DESCRIPTION
- Added the visible checkbox to every node (except the scene)
- Added the walkable checkbox to model, box collider, and ground plane nodes.
- Added the collidable checkbox to model nodes.
- A floor plan node is included in the default new scene.
- Floor plan nodes can be configured and regenerated in the properties pane.
- Old scenes will have their nodes migrated to include walkable, collidable, visible, and floor-plan components accordingly.
- The floorplan's walkable area has been reduced so that it can be included in the nav mesh generation.
- `serialize()` and `prepareForExport()` were refactored to dry up adding the `visible` component when necessary.

Fixes #307 
Fixes #274 