### PR TITLE
Experimental play mode

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -568,7 +568,6 @@ export default class Editor {
     this.deselect();
     this.camera.layers.disable(1);
     this.viewport.controls.enabled = false;
-    this.viewport.inputManager.enabled = true;
     this.viewport.flyControls.enable();
 
     this.scene.traverse(node => {
@@ -582,7 +581,6 @@ export default class Editor {
     this.playing = false;
     this.camera.layers.enable(1);
     this.viewport.controls.enabled = true;
-    this.viewport.inputManager.enabled = false;
     this.viewport.flyControls.disable();
 
     this.scene.traverse(node => {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -562,4 +562,29 @@ export default class Editor {
 
     return blob;
   }
+
+  enterPlayMode() {
+    this.playing = true;
+    this.deselect();
+    this.camera.layers.disable(1);
+    this.viewport.controls.enabled = false;
+
+    this.scene.traverse(node => {
+      if (node.isNode) {
+        node.onPlay();
+      }
+    });
+  }
+
+  leavePlayMode() {
+    this.playing = false;
+    this.camera.layers.enable(1);
+    this.viewport.controls.enabled = true;
+
+    this.scene.traverse(node => {
+      if (node.isNode) {
+        node.onPause();
+      }
+    });
+  }
 }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -568,6 +568,8 @@ export default class Editor {
     this.deselect();
     this.camera.layers.disable(1);
     this.viewport.controls.enabled = false;
+    this.viewport.inputManager.enabled = true;
+    this.viewport.flyControls.enable();
 
     this.scene.traverse(node => {
       if (node.isNode) {
@@ -580,6 +582,8 @@ export default class Editor {
     this.playing = false;
     this.camera.layers.enable(1);
     this.viewport.controls.enabled = true;
+    this.viewport.inputManager.enabled = false;
+    this.viewport.flyControls.disable();
 
     this.scene.traverse(node => {
       if (node.isNode) {

--- a/src/editor/Viewport.js
+++ b/src/editor/Viewport.js
@@ -9,6 +9,8 @@ import OutlinePass from "./renderer/OutlinePass";
 import { environmentMap } from "./utils/EnvironmentMap";
 import { traverseMaterials } from "./utils/materials";
 import { getCanvasBlob } from "./utils/thumbnails";
+import InputManager from "./controls/InputManager";
+import FlyControls from "./controls/FlyControls";
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -70,6 +72,9 @@ export default class Viewport {
     this.objectRotationOnDown = null;
     this.objectScaleOnDown = null;
 
+    this.inputManager = new InputManager(canvas);
+    this.flyControls = new FlyControls(camera, this.inputManager);
+
     this.skipRender = false;
 
     this.clock = new THREE.Clock();
@@ -78,6 +83,7 @@ export default class Viewport {
       if (!this.skipRender) {
         const delta = this.clock.getDelta();
         editor.scene.updateMatrixWorld();
+        this.inputManager.update();
 
         editor.scene.traverse(node => {
           if (node.isDirectionalLight) {
@@ -89,8 +95,10 @@ export default class Viewport {
           }
         });
         this.transformControls.update();
+        this.flyControls.update(delta);
         effectComposer.render();
         signals.sceneRendered.dispatch(renderer, editor.scene);
+        this.inputManager.reset();
       }
 
       this.rafId = requestAnimationFrame(render);

--- a/src/editor/Viewport.js
+++ b/src/editor/Viewport.js
@@ -205,6 +205,8 @@ export default class Viewport {
   onCanvasMouseDown = event => {
     event.preventDefault();
 
+    if (this.editor.playing) return;
+
     this.canvas.focus();
 
     const array = this.getMousePosition(this.canvas, event.clientX, event.clientY);
@@ -214,6 +216,8 @@ export default class Viewport {
   };
 
   onCanvasMouseUp = event => {
+    if (this.editor.playing) return;
+
     const array = this.getMousePosition(this.canvas, event.clientX, event.clientY);
     this.onUpPosition.fromArray(array);
 
@@ -223,6 +227,8 @@ export default class Viewport {
   };
 
   onCanvasTouchStart = event => {
+    if (this.editor.playing) return;
+
     const touch = event.changedTouches[0];
 
     const array = this.getMousePosition(this.canvas, touch.clientX, touch.clientY);
@@ -232,6 +238,8 @@ export default class Viewport {
   };
 
   onCanvasTouchEnd = event => {
+    if (this.editor.playing) return;
+
     const touch = event.changedTouches[0];
 
     const array = this.getMousePosition(this.canvas, touch.clientX, touch.clientY);
@@ -243,6 +251,8 @@ export default class Viewport {
   };
 
   onCanvasDoubleClick = event => {
+    if (this.editor.playing) return;
+
     const array = this.getMousePosition(this.canvas, event.clientX, event.clientY);
     this.onDoubleClickPosition.fromArray(array);
 
@@ -313,6 +323,8 @@ export default class Viewport {
   };
 
   onObjectSelected = object => {
+    if (this.editor.playing) return;
+
     this.transformControls.detach();
 
     if (
@@ -336,6 +348,7 @@ export default class Viewport {
   };
 
   onObjectFocused = object => {
+    if (this.editor.playing) return;
     this.controls.focus(object);
   };
 

--- a/src/editor/controls/FlyControls.js
+++ b/src/editor/controls/FlyControls.js
@@ -1,0 +1,52 @@
+import { Fly, FlyMapping } from "./input-mappings";
+import THREE from "../../vendor/three";
+
+export default class FlyControls {
+  constructor(camera, inputManager) {
+    this.enabled = false;
+    this.camera = camera;
+    this.inputManager = inputManager;
+    this.moveSpeed = 2;
+    this.boostSpeed = 2;
+    this.lookSensitivity = 1;
+    this.direction = new THREE.Vector3();
+    this.maxXRotation = THREE.Math.degToRad(70);
+  }
+
+  enable() {
+    this.enabled = true;
+    this.inputManager.setInputMapping(FlyMapping);
+    this.camera.rotation.set(0, 0, 0);
+  }
+
+  disable() {
+    this.enabled = false;
+    this.inputManager.setInputMapping({});
+  }
+
+  update(dt) {
+    if (!this.enabled || !this.inputManager.enabled) return;
+
+    const input = this.inputManager;
+
+    const rotation = this.camera.rotation;
+    const lookSensitivity = this.lookSensitivity;
+
+    let xRotation = rotation.x > Math.PI ? rotation.x - 2 * Math.PI : rotation.x;
+    xRotation = THREE.Math.clamp(xRotation, -this.maxXRotation, this.maxXRotation);
+
+    rotation.set(
+      xRotation + input.get(Fly.lookY) * lookSensitivity,
+      rotation.y + input.get(Fly.lookX) * lookSensitivity,
+      0,
+      "ZYX"
+    );
+
+    this.direction.set(input.get(Fly.moveX), 0, input.get(Fly.moveZ));
+
+    const boostSpeed = input.get(Fly.boost) ? this.boostSpeed : 1;
+    const speed = dt * this.moveSpeed * boostSpeed;
+
+    this.camera.translateOnAxis(this.direction, speed);
+  }
+}

--- a/src/editor/controls/FlyControls.js
+++ b/src/editor/controls/FlyControls.js
@@ -11,7 +11,14 @@ export default class FlyControls {
     this.lookSensitivity = 1;
     this.direction = new THREE.Vector3();
     this.maxXRotation = THREE.Math.degToRad(70);
+    this.inputManager.canvas.addEventListener("click", this.onClickCanvas);
   }
+
+  onClickCanvas = () => {
+    if (this.enabled && document.pointerLockElement !== this.inputManager.canvas) {
+      this.inputManager.canvas.requestPointerLock();
+    }
+  };
 
   enable() {
     this.enabled = true;
@@ -22,10 +29,11 @@ export default class FlyControls {
   disable() {
     this.enabled = false;
     this.inputManager.setInputMapping({});
+    this.inputManager.canvas.exitPointerLock();
   }
 
   update(dt) {
-    if (!this.enabled || !this.inputManager.enabled) return;
+    if (!this.enabled || document.pointerLockElement !== this.inputManager.canvas) return;
 
     const input = this.inputManager;
 

--- a/src/editor/controls/FlyControls.js
+++ b/src/editor/controls/FlyControls.js
@@ -29,7 +29,7 @@ export default class FlyControls {
   disable() {
     this.enabled = false;
     this.inputManager.setInputMapping({});
-    this.inputManager.canvas.exitPointerLock();
+    document.exitPointerLock();
   }
 
   update(dt) {

--- a/src/editor/controls/InputManager.js
+++ b/src/editor/controls/InputManager.js
@@ -16,30 +16,10 @@ export default class InputManager {
     this.mapping = {};
     this.initialState = {};
     this.state = {};
-    this._enabled = false;
 
     window.addEventListener("keydown", this.onKeyDown);
     window.addEventListener("keyup", this.onKeyUp);
     window.addEventListener("mousemove", this.onMouseMove);
-    this.canvas.addEventListener("click", this.onClickCanvas);
-  }
-
-  onClickCanvas = () => {
-    if (this._enabled && document.pointerLockElement !== this.canvas) {
-      this.canvas.requestPointerLock();
-    }
-  };
-
-  exitPointerLock() {
-    this.canvas.exitPointerLock();
-  }
-
-  set enabled(enabled) {
-    this._enabled = enabled;
-  }
-
-  get enabled() {
-    return document.pointerLockElement === this.canvas && this._enabled;
   }
 
   setInputMapping(mapping) {
@@ -71,8 +51,6 @@ export default class InputManager {
   }
 
   onKeyDown = event => {
-    if (!this.enabled) return;
-
     const keyboardMapping = this.mapping.keyboard;
 
     if (!keyboardMapping) return;
@@ -99,8 +77,6 @@ export default class InputManager {
   };
 
   onKeyUp = event => {
-    if (!this.enabled) return;
-
     const keyboardMapping = this.mapping.keyboard;
 
     if (!keyboardMapping) return;
@@ -127,8 +103,6 @@ export default class InputManager {
   };
 
   onMouseMove = event => {
-    if (!this.enabled) return;
-
     const mouseMapping = this.mapping.mouse;
 
     if (!mouseMapping) return;
@@ -145,8 +119,6 @@ export default class InputManager {
   };
 
   update() {
-    if (!this.enabled) return;
-
     const computed = this.mapping.computed;
 
     if (computed) {
@@ -157,8 +129,6 @@ export default class InputManager {
   }
 
   reset() {
-    if (!this.enabled) return;
-
     const mouseMapping = this.mapping.mouse;
 
     if (mouseMapping && mouseMapping.move) {

--- a/src/editor/controls/InputManager.js
+++ b/src/editor/controls/InputManager.js
@@ -1,0 +1,184 @@
+function initializeValue(source, target, value) {
+  if (!source) return;
+
+  for (const sourceKey in source) {
+    if (source.hasOwnProperty(sourceKey)) {
+      const targetKey = source[sourceKey];
+      target[targetKey] = value;
+    }
+  }
+}
+
+export default class InputManager {
+  constructor(canvas) {
+    this.canvas = canvas;
+
+    this.mapping = {};
+    this.initialState = {};
+    this.state = {};
+    this._enabled = false;
+
+    window.addEventListener("keydown", this.onKeyDown);
+    window.addEventListener("keyup", this.onKeyUp);
+    window.addEventListener("mousemove", this.onMouseMove);
+    this.canvas.addEventListener("click", this.onClickCanvas);
+  }
+
+  onClickCanvas = () => {
+    if (this._enabled && document.pointerLockElement !== this.canvas) {
+      this.canvas.requestPointerLock();
+    }
+  };
+
+  exitPointerLock() {
+    this.canvas.exitPointerLock();
+  }
+
+  set enabled(enabled) {
+    this._enabled = enabled;
+  }
+
+  get enabled() {
+    return document.pointerLockElement === this.canvas && this._enabled;
+  }
+
+  setInputMapping(mapping) {
+    this.mapping = mapping;
+
+    const initialState = this.initialState;
+
+    const keyboard = mapping.keyboard;
+
+    if (keyboard) {
+      initializeValue(keyboard.pressed, initialState, 0);
+      initializeValue(keyboard.keydown, initialState, 0);
+      initializeValue(keyboard.keyup, initialState, 0);
+    }
+
+    const mouse = mapping.mouse;
+
+    if (mouse) {
+      initializeValue(mouse.move, initialState, 0);
+    }
+
+    const computed = mapping.computed;
+
+    if (computed) {
+      for (const { action, transform, defaultValue } of computed) {
+        initialState[action] = defaultValue !== undefined ? defaultValue : transform(this);
+      }
+    }
+  }
+
+  onKeyDown = event => {
+    if (!this.enabled) return;
+
+    const keyboardMapping = this.mapping.keyboard;
+
+    if (!keyboardMapping) return;
+
+    const pressedMapping = keyboardMapping.pressed;
+
+    if (pressedMapping) {
+      const key = pressedMapping[event.key.toLowerCase()];
+
+      if (key) {
+        this.state[key] = 1;
+      }
+    }
+
+    const keydownMapping = keyboardMapping.keydown;
+
+    if (keydownMapping) {
+      const key = keydownMapping[event.key.toLowerCase()];
+
+      if (key) {
+        this.state[key] = 1;
+      }
+    }
+  };
+
+  onKeyUp = event => {
+    if (!this.enabled) return;
+
+    const keyboardMapping = this.mapping.keyboard;
+
+    if (!keyboardMapping) return;
+
+    const pressedMapping = keyboardMapping.pressed;
+
+    if (pressedMapping) {
+      const key = pressedMapping[event.key.toLowerCase()];
+
+      if (key) {
+        this.state[key] = 0;
+      }
+    }
+
+    const keyupMapping = keyboardMapping.keyup;
+
+    if (keyupMapping) {
+      const key = keyupMapping[event.key.toLowerCase()];
+
+      if (key) {
+        this.state[key] = 0;
+      }
+    }
+  };
+
+  onMouseMove = event => {
+    if (!this.enabled) return;
+
+    const mouseMapping = this.mapping.mouse;
+
+    if (!mouseMapping) return;
+
+    const moveMapping = mouseMapping.move;
+
+    if (!moveMapping) return;
+
+    for (const key in moveMapping) {
+      if (moveMapping.hasOwnProperty(key)) {
+        this.state[moveMapping[key]] += event[key];
+      }
+    }
+  };
+
+  update() {
+    if (!this.enabled) return;
+
+    const computed = this.mapping.computed;
+
+    if (computed) {
+      for (const { action, transform } of computed) {
+        this.state[action] = transform(this);
+      }
+    }
+  }
+
+  reset() {
+    if (!this.enabled) return;
+
+    const mouseMapping = this.mapping.mouse;
+
+    if (mouseMapping && mouseMapping.move) {
+      const moveMapping = mouseMapping.move;
+
+      for (const key in moveMapping) {
+        if (moveMapping.hasOwnProperty(key)) {
+          this.state[moveMapping[key]] = 0;
+        }
+      }
+    }
+  }
+
+  get(key) {
+    return this.state[key] || 0;
+  }
+
+  dispose() {
+    window.removeEventListener("keydown", this.onKeyDown);
+    window.removeEventListener("keyup", this.onKeyUp);
+    window.removeEventListener("mousemove", this.onMouseMove);
+  }
+}

--- a/src/editor/controls/input-mappings.js
+++ b/src/editor/controls/input-mappings.js
@@ -1,0 +1,52 @@
+let nextId = 1;
+const Id = () => nextId++;
+
+export const Fly = {
+  moveLeft: Id(),
+  moveRight: Id(),
+  moveX: Id(),
+  moveForward: Id(),
+  moveBackward: Id(),
+  moveZ: Id(),
+  lookDeltaX: Id(),
+  lookDeltaY: Id(),
+  lookX: Id(),
+  lookY: Id(),
+  boost: Id()
+};
+
+export const FlyMapping = {
+  keyboard: {
+    pressed: {
+      w: Fly.moveForward,
+      a: Fly.moveLeft,
+      s: Fly.moveBackward,
+      d: Fly.moveRight,
+      shift: Fly.boost
+    }
+  },
+  mouse: {
+    move: {
+      movementX: Fly.lookDeltaX,
+      movementY: Fly.lookDeltaY
+    }
+  },
+  computed: [
+    {
+      transform: input => input.get(Fly.moveRight) - input.get(Fly.moveLeft),
+      action: Fly.moveX
+    },
+    {
+      transform: input => input.get(Fly.moveBackward) - input.get(Fly.moveForward),
+      action: Fly.moveZ
+    },
+    {
+      transform: input => -input.get(Fly.lookDeltaX) / input.canvas.clientWidth,
+      action: Fly.lookX
+    },
+    {
+      transform: input => -input.get(Fly.lookDeltaY) / input.canvas.clientHeight,
+      action: Fly.lookY
+    }
+  ]
+};

--- a/src/editor/nodes/EditorNodeMixin.js
+++ b/src/editor/nodes/EditorNodeMixin.js
@@ -83,11 +83,15 @@ export default function EditorNodeMixin(Object3DClass) {
       return this;
     }
 
+    onPlay() {}
+
     onUpdate(dt) {
       if (this.loadingCube) {
         this.loadingCube.update(dt);
       }
     }
+
+    onPause() {}
 
     onAdd() {}
 
@@ -240,6 +244,7 @@ export default function EditorNodeMixin(Object3DClass) {
     hideLoadingCube() {
       if (this.loadingCube) {
         this.remove(this.loadingCube);
+        this.loadingCube = null;
       }
     }
 

--- a/src/editor/nodes/ImageNode.js
+++ b/src/editor/nodes/ImageNode.js
@@ -11,9 +11,12 @@ export default class ImageNode extends EditorNodeMixin(Image) {
 
     const { src, projection } = json.components.find(c => c.name === "image").props;
 
-    loadAsync(node.load(src));
-
-    node.projection = projection;
+    loadAsync(
+      (async () => {
+        await node.load(src);
+        node.projection = projection;
+      })()
+    );
 
     return node;
   }
@@ -42,6 +45,7 @@ export default class ImageNode extends EditorNodeMixin(Image) {
 
   async load(src) {
     this.showLoadingCube();
+    this._mesh.visible = false;
     this._canonicalUrl = src || "";
 
     try {

--- a/src/editor/nodes/VideoNode.js
+++ b/src/editor/nodes/VideoNode.js
@@ -29,21 +29,24 @@ export default class VideoNode extends EditorNodeMixin(Video) {
       projection
     } = json.components.find(c => c.name === "video").props;
 
-    loadAsync(node.load(src));
-
-    node.controls = controls;
-    node.autoPlay = autoPlay;
-    node.loop = loop;
-    node.audioType = audioType;
-    node.volume = volume;
-    node.distanceModel = distanceModel;
-    node.rolloffFactor = rolloffFactor;
-    node.refDistance = refDistance;
-    node.maxDistance = maxDistance;
-    node.coneInnerAngle = coneInnerAngle;
-    node.coneOuterAngle = coneOuterAngle;
-    node.coneOuterGain = coneOuterGain;
-    node.projection = projection;
+    loadAsync(
+      (async () => {
+        await node.load(src);
+        node.controls = controls;
+        node.autoPlay = autoPlay;
+        node.loop = loop;
+        node.audioType = audioType;
+        node.volume = volume;
+        node.distanceModel = distanceModel;
+        node.rolloffFactor = rolloffFactor;
+        node.refDistance = refDistance;
+        node.maxDistance = maxDistance;
+        node.coneInnerAngle = coneInnerAngle;
+        node.coneOuterAngle = coneOuterAngle;
+        node.coneOuterGain = coneOuterGain;
+        node.projection = projection;
+      })()
+    );
 
     return node;
   }
@@ -74,7 +77,12 @@ export default class VideoNode extends EditorNodeMixin(Video) {
 
   async load(src) {
     this.showLoadingCube();
+    this._mesh.visible = false;
     this._canonicalUrl = src || "";
+
+    if (this.editor.playing) {
+      this.videoEl.pause();
+    }
 
     try {
       const { accessibleUrl, contentType } = await this.editor.api.resolveMedia(src);
@@ -108,6 +116,10 @@ export default class VideoNode extends EditorNodeMixin(Video) {
       } else if (this.videoEl.duration) {
         this.videoEl.currentTime = 1;
       }
+
+      if (this.editor.playing && this.autoPlay) {
+        this.videoEl.play();
+      }
     } catch (e) {
       console.error(e);
     }
@@ -115,6 +127,17 @@ export default class VideoNode extends EditorNodeMixin(Video) {
     this.hideLoadingCube();
 
     return this;
+  }
+
+  onPlay() {
+    if (this.autoPlay) {
+      this.videoEl.play();
+    }
+  }
+
+  onPause() {
+    this.videoEl.pause();
+    this.videoEl.currentTime = 0;
   }
 
   onChange() {

--- a/src/editor/objects/Image.js
+++ b/src/editor/objects/Image.js
@@ -65,6 +65,7 @@ export default class Image extends THREE.Object3D {
 
   async load(src) {
     this._src = src;
+    this._mesh.visible = false;
 
     const material = this._mesh.material;
 
@@ -74,6 +75,7 @@ export default class Image extends THREE.Object3D {
 
     if (!src) {
       material.map = null;
+      this._mesh.visible = true;
       return;
     }
 
@@ -103,6 +105,7 @@ export default class Image extends THREE.Object3D {
 
     this._mesh.material.map = this._texture;
     this._mesh.material.needsUpdate = true;
+    this._mesh.visible = true;
 
     return this;
   }

--- a/src/editor/objects/Model.js
+++ b/src/editor/objects/Model.js
@@ -7,6 +7,7 @@ export default class Model extends THREE.Object3D {
     super();
     this.type = "Model";
 
+    this.model = null;
     this._src = null;
     this.animations = [];
     this.clipActions = [];
@@ -33,19 +34,25 @@ export default class Model extends THREE.Object3D {
 
   async load(src) {
     this._src = src;
-
-    const { scene, animations } = await this.loadGLTF(src);
-
-    if (animations) {
-      this.animations = this.animations.concat(animations);
-    }
+    this.animations = [];
+    this.clipActions = [];
+    this._mixer = new THREE.AnimationMixer(this);
 
     if (this.model) {
       this.remove(this.model);
     }
 
+    const { scene, animations } = await this.loadGLTF(src);
+
+    if (animations) {
+      this.animations = animations;
+    }
+
     this.model = scene;
     this.add(scene);
+
+    this.castShadow = this._castShadow;
+    this.receiveShadow = this._receiveShadow;
 
     return this;
   }

--- a/src/editor/objects/Video.js
+++ b/src/editor/objects/Video.js
@@ -42,6 +42,7 @@ export default class Video extends THREE.Object3D {
     videoEl.setAttribute("playsinline", "");
     videoEl.setAttribute("webkit-playsinline", "");
     videoEl.crossOrigin = "anonymous";
+    videoEl.loop = true;
     this.videoEl = videoEl;
 
     this.audioListener = audioListener;
@@ -86,11 +87,17 @@ export default class Video extends THREE.Object3D {
 
   set audioType(type) {
     let audio;
+    const oldAudio = this.audio;
 
     if (type === AudioType.PannerNode) {
       audio = new THREE.PositionalAudio(this.audioListener);
     } else {
       audio = new THREE.Audio(this.audioListener);
+    }
+
+    if (oldAudio) {
+      audio.gain.gain.value = oldAudio.getVolume();
+      oldAudio.disconnect();
     }
 
     if (this.audioSource) {
@@ -272,10 +279,13 @@ export default class Video extends THREE.Object3D {
     this.remove(this._mesh);
     this._mesh = new THREE.Mesh(geometry, material);
     this.add(this._mesh);
+    this.onResize();
   }
 
   async load(src, contentType) {
     let texture;
+
+    this._mesh.visible = false;
 
     try {
       if (src) {
@@ -301,6 +311,7 @@ export default class Video extends THREE.Object3D {
 
     this._mesh.material.map = this._texture;
     this._mesh.material.needsUpdate = true;
+    this._mesh.visible = true;
 
     return this;
   }


### PR DESCRIPTION
- Adds `editor.enterPlayMode()` and `editor.leavePlayMode()` which can be toggled in the dev tools.
  - Play mode currently plays videos and animations. It also uses the new FlyControls camera controller so you can fly around your scene.
  - You can still edit properties in the properties panel while in play mode although this probably still has some bugs in edge cases.
  - Play mode is still experimental so save your work often if you are going to use it!
- Fixes a regression in deserializing animations
- Introduces a simple InputManager with input mappings and transforms
- Fixes image/video/models showing during loading cube animation
- Fixes #441 
- Fixes #406 